### PR TITLE
Disable support for 32-bit RISC-V

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ target_compile_definitions(riscv PUBLIC
 	RISCV_SYSCALLS_MAX=600
 	RISCV_BRK_MEMORY_SIZE=0x100000  # 1MB (we don't need much)
 )
-if (RISCV_LIBTCC)
+if (RISCV_BINARY_TRANSLATION AND RISCV_LIBTCC)
 	target_compile_options(libtcc PRIVATE -fPIC)
 endif()
 

--- a/SConstruct
+++ b/SConstruct
@@ -30,7 +30,7 @@ librisc_sources = [
 	"libriscv/lib/libriscv/multiprocessing.cpp",
 	"libriscv/lib/libriscv/native_libc.cpp",
 	"libriscv/lib/libriscv/native_threads.cpp",
-	"libriscv/lib/libriscv/rv32i.cpp",
+	#"libriscv/lib/libriscv/rv32i.cpp",
 	"libriscv/lib/libriscv/rv64i.cpp",
 	"libriscv/lib/libriscv/serialize.cpp",
 

--- a/libriscv_settings.h
+++ b/libriscv_settings.h
@@ -8,7 +8,7 @@
 #define RISCV_EXT_A
 #define RISCV_EXT_C
 /* #undef RISCV_EXT_V */
-#define RISCV_32I
+/* #undef RISCV_32I */
 #define RISCV_64I
 /* #undef RISCV_128I */
 /* #undef RISCV_FCSR */


### PR DESCRIPTION
The API currently only uses 64-bit RISC-V anyway