### PR TITLE
Implement usage of native-performing libc functions in C++

### DIFF
--- a/program/api/native.cpp
+++ b/program/api/native.cpp
@@ -1,0 +1,139 @@
+#include "syscalls.h"
+#include <cstddef>
+
+#define NATIVE_MEM_FUNCATTR /* */
+#define NATIVE_SYSCALLS_BASE 480 /* libc starts at 480 */
+
+#define SYSCALL_MALLOC (NATIVE_SYSCALLS_BASE + 0)
+#define SYSCALL_CALLOC (NATIVE_SYSCALLS_BASE + 1)
+#define SYSCALL_REALLOC (NATIVE_SYSCALLS_BASE + 2)
+#define SYSCALL_FREE (NATIVE_SYSCALLS_BASE + 3)
+#define SYSCALL_MEMINFO (NATIVE_SYSCALLS_BASE + 4)
+
+#define SYSCALL_MEMCPY (NATIVE_SYSCALLS_BASE + 5)
+#define SYSCALL_MEMSET (NATIVE_SYSCALLS_BASE + 6)
+#define SYSCALL_MEMMOVE (NATIVE_SYSCALLS_BASE + 7)
+#define SYSCALL_MEMCMP (NATIVE_SYSCALLS_BASE + 8)
+
+#define SYSCALL_STRLEN (NATIVE_SYSCALLS_BASE + 10)
+#define SYSCALL_STRCMP (NATIVE_SYSCALLS_BASE + 11)
+
+#define SYSCALL_BACKTRACE (NATIVE_SYSCALLS_BASE + 19)
+
+extern "C" void *__wrap_malloc(size_t size) {
+	register void *ret __asm__("a0");
+	register size_t a0 __asm__("a0") = size;
+	register long syscall_id __asm__("a7") = SYSCALL_MALLOC;
+
+	asm volatile("ecall"
+				 : "=m"(*(char(*)[size])ret), "=r"(ret)
+				 : "r"(a0), "r"(syscall_id));
+	return ret;
+}
+extern "C" void __wrap_free(void *ptr) {
+	register void *a0 __asm__("a0") = ptr;
+	register long syscall_id __asm__("a7") = SYSCALL_FREE;
+
+	asm volatile("ecall"
+				 :
+				 : "r"(a0), "r"(syscall_id));
+}
+
+#define STR1(x) #x
+#define STR(x) STR1(x)
+
+__asm__(".pushsection .text\n"
+		".global __wrap_calloc\n"
+		".type __wrap_calloc, @function\n"
+		"__wrap_calloc:\n"
+		"	li a7, " STR(SYSCALL_CALLOC) "\n"
+										 "	ecall\n"
+										 "	ret\n"
+										 ".global __wrap_realloc\n"
+										 ".type __wrap_realloc, @function\n"
+										 "__wrap_realloc:\n"
+										 "	li a7, " STR(SYSCALL_REALLOC) "\n"
+																		  "	ecall\n"
+																		  "	ret\n"
+																		  ".popsection .text\n");
+
+extern "C" void *__wrap_memset(void *vdest, const int ch, size_t size) {
+	register char *a0 __asm__("a0") = (char *)vdest;
+	register int a1 __asm__("a1") = ch;
+	register size_t a2 __asm__("a2") = size;
+	register long syscall_id __asm__("a7") = SYSCALL_MEMSET;
+
+	asm volatile("ecall"
+				 : "=m"(*(char(*)[size])a0)
+				 : "r"(a0), "r"(a1), "r"(a2), "r"(syscall_id));
+	return vdest;
+}
+extern "C" void *__wrap_memcpy(void *vdest, const void *vsrc, size_t size) {
+	register char *a0 __asm__("a0") = (char *)vdest;
+	register const char *a1 __asm__("a1") = (const char *)vsrc;
+	register size_t a2 __asm__("a2") = size;
+	register long syscall_id __asm__("a7") = SYSCALL_MEMCPY;
+
+	asm volatile("ecall"
+				 : "=m"(*(char(*)[size])a0), "+r"(a0)
+				 : "r"(a1), "m"(*(const char(*)[size])a1),
+				 "r"(a2), "r"(syscall_id));
+	return vdest;
+}
+extern "C" void *__wrap_memmove(void *vdest, const void *vsrc, size_t size) {
+	// An assumption is being made here that since vsrc might be
+	// inside vdest, we cannot assume that vsrc is const anymore.
+	register char *a0 __asm__("a0") = (char *)vdest;
+	register char *a1 __asm__("a1") = (char *)vsrc;
+	register size_t a2 __asm__("a2") = size;
+	register long syscall_id __asm__("a7") = SYSCALL_MEMMOVE;
+
+	asm volatile("ecall"
+				 : "=m"(*(char(*)[size])a0), "=m"(*(char(*)[size])a1)
+				 : "r"(a0), "r"(a1), "r"(a2), "r"(syscall_id));
+	return vdest;
+}
+extern "C" int __wrap_memcmp(const void *m1, const void *m2, size_t size) {
+	register const char *a0 __asm__("a0") = (const char *)m1;
+	register const char *a1 __asm__("a1") = (const char *)m2;
+	register size_t a2 __asm__("a2") = size;
+	register long syscall_id __asm__("a7") = SYSCALL_MEMCMP;
+	register int a0_out __asm__("a0");
+
+	asm volatile("ecall" : "=r"(a0_out) : "r"(a0), "m"(*(const char(*)[size])a0),
+				 "r"(a1), "m"(*(const char(*)[size])a1),
+				 "r"(a2), "r"(syscall_id));
+	return a0_out;
+}
+extern "C" size_t __wrap_strlen(const char *str) {
+	register const char *a0 __asm__("a0") = str;
+	register size_t a0_out __asm__("a0");
+	register long syscall_id __asm__("a7") = SYSCALL_STRLEN;
+
+	asm volatile("ecall" : "=r"(a0_out) : "r"(a0), "m"(*(const char(*)[4096])a0), "r"(syscall_id));
+	return a0_out;
+}
+extern "C" int __wrap_strcmp(const char *str1, const char *str2) {
+	register const char *a0 __asm__("a0") = str1;
+	register const char *a1 __asm__("a1") = str2;
+	register size_t a2 __asm__("a2") = 4096;
+	register size_t a0_out __asm__("a0");
+	register long syscall_id __asm__("a7") = SYSCALL_STRCMP;
+
+	asm volatile("ecall" : "=r"(a0_out) : "r"(a0), "m"(*(const char(*)[4096])a0),
+				 "r"(a1), "m"(*(const char(*)[4096])a1),
+				 "r"(a2), "r"(syscall_id));
+	return a0_out;
+}
+extern "C" int __wrap_strncmp(const char *str1, const char *str2, size_t maxlen) {
+	register const char *a0 __asm__("a0") = str1;
+	register const char *a1 __asm__("a1") = str2;
+	register size_t a2 __asm__("a2") = maxlen;
+	register size_t a0_out __asm__("a0");
+	register long syscall_id __asm__("a7") = SYSCALL_STRCMP;
+
+	asm volatile("ecall" : "=r"(a0_out) : "r"(a0), "m"(*(const char(*)[maxlen])a0),
+				 "r"(a1), "m"(*(const char(*)[maxlen])a1),
+				 "r"(a2), "r"(syscall_id));
+	return a0_out;
+}

--- a/program/build.sh
+++ b/program/build.sh
@@ -19,4 +19,9 @@ if [ -z "$output" ]; then
 	usage
 fi
 
-riscv64-linux-gnu-g++-14 -static -O2 -std=gnu++23 -I/usr/api -fuse-ld=mold -Wl,--execute-only /usr/api/*.cpp -o $output $@
+MEMOPS=-Wl,--wrap=memcpy,--wrap=memset,--wrap=memcmp,--wrap=memmove
+STROPS=-Wl,--wrap=strlen,--wrap=strcmp,--wrap=strncmp
+HEAPOPS=-Wl,--wrap=malloc,--wrap=calloc,--wrap=realloc,--wrap=free
+LINKEROPS="-fuse-ld=mold -Wl,--execute-only $MEMOPS $STROPS $HEAPOPS"
+
+riscv64-linux-gnu-g++-14 -static -O2 -std=gnu++23 -I/usr/api $LINKEROPS /usr/api/*.cpp -o $output $@


### PR DESCRIPTION
This PR makes sure that common string-, memory- and heap-operations all have native performance on all platforms.
