### PR TITLE
Rework Variant, reducing size and increasing efficiency

### DIFF
--- a/program/cpp/api/variant.hpp
+++ b/program/cpp/api/variant.hpp
@@ -183,14 +183,12 @@ struct Variant
 
 	Type get_type() const noexcept { return m_type; }
 
-	static constexpr unsigned GODOT_VARIANT_SIZE = 24;
 private:
 	Type m_type = NIL;
 	union {
-		uint8_t opaque[GODOT_VARIANT_SIZE] { 0 };
+		int64_t i = 0;
 		bool    b;
-		int64_t i;
-		double  f;
+		float   f;
 		Vector2  v2;
 		Vector2i v2i;
 		Vector3  v3;
@@ -204,6 +202,7 @@ private:
 		std::vector<double> *f64array;
 	} v;
 };
+static_assert(sizeof(Variant) == 24, "Variant size mismatch");
 
 template <typename T>
 inline Variant::Variant(T value)
@@ -332,15 +331,19 @@ inline Variant::operator uint8_t() const
 
 inline Variant::operator double() const
 {
-	if (m_type == FLOAT || m_type == INT)
-		return v.f;
+	if (m_type == FLOAT)
+		return static_cast<double>(v.f);
+	if (m_type == INT)
+		return static_cast<double>(v.i);
 	api_throw("std::bad_cast", "Failed to cast Variant to double", this);
 }
 
 inline Variant::operator float() const
 {
-	if (m_type == FLOAT || m_type == INT)
-		return static_cast<float>(v.f);
+	if (m_type == FLOAT)
+		return v.f;
+	if (m_type == INT)
+		return static_cast<float>(v.i);
 	api_throw("std::bad_cast", "Failed to cast Variant to float", this);
 }
 

--- a/program/rust/src/godot/variant.rs
+++ b/program/rust/src/godot/variant.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 use std::arch::asm;
-const VARIANT_SIZE: usize = 24;
 
 #[repr(C)]
 pub enum VariantType {
@@ -85,7 +84,7 @@ pub struct Vector4i {
 pub union VariantUnion {
 	pub b: bool,
 	pub i: i64,
-	pub f: f64,
+	pub f: f32,
 	pub v2: Vector2,
 	pub v2i: Vector2i,
 	pub v3: Vector3,
@@ -95,8 +94,6 @@ pub union VariantUnion {
 	pub v4: Vector4,
 	pub v4i: Vector4i,
 	pub s: *const VariantStdString,
-	// 24 bytes total
-	pub a: [u8; VARIANT_SIZE],
 }
 
 #[repr(C)]
@@ -124,7 +121,7 @@ impl Variant
 		let v = Variant { t: VariantType::Integer, u: VariantUnion { i: i } };
 		return v;
 	}
-	pub fn new_float(f: f64) -> Variant
+	pub fn new_float(f: f32) -> Variant
 	{
 		let v = Variant { t: VariantType::Float, u: VariantUnion { f: f } };
 		return v;
@@ -197,7 +194,7 @@ impl Variant
 		}
 	}
 
-	pub fn to_float(&self) -> f64
+	pub fn to_float(&self) -> f32
 	{
 		match self.t {
 			VariantType::Float => {


### PR DESCRIPTION
- Guest Variant size reduced from 32- to 24-bytes
- Float is now 32-bit (matching default real_t)
- Scoped variants have call-lifetime and only needs an index
- Only add scoped variants when trust is implicit

NOTE: All programs will need to be rebuilt