### PR TITLE
Avoid setting the global name.

### DIFF
--- a/src/elf/script_elf.cpp
+++ b/src/elf/script_elf.cpp
@@ -234,7 +234,6 @@ String ELFScript::get_elf_programming_language() const {
 void ELFScript::set_file(const String &p_path) {
 	path = p_path;
 	source_code = FileAccess::get_file_as_bytes(path);
-	global_name = "Sandbox_" + path.get_basename().replace("res://", "").replace("/", "_").capitalize().replace(" ", "");
 	Sandbox::BinaryInfo info = Sandbox::get_program_info_from_binary(source_code);
 	info.functions.sort();
 	this->functions = std::move(info.functions);


### PR DESCRIPTION
The name should be set by the developer and it shouldn't be set via the path or any other way by elfscript.

The usage in godot-sandbox-demo should be using the godot get_node() get property ways of getting the player name

Matches rustscript.