### PR TITLE
Add new low-latency mode that uses primitive types for certain VM call arguments

### DIFF
--- a/program/cpp/api/array.cpp
+++ b/program/cpp/api/array.cpp
@@ -4,7 +4,7 @@
 
 MAKE_SYSCALL(ECALL_ARRAY_OPS, void, sys_array_ops, Array_Op, unsigned, int, Variant *);
 MAKE_SYSCALL(ECALL_ARRAY_AT, void, sys_array_at, unsigned, int, Variant *);
-MAKE_SYSCALL(ECALL_ARRAY_SIZE, void, sys_array_size, unsigned);
+MAKE_SYSCALL(ECALL_ARRAY_SIZE, int, sys_array_size, unsigned);
 
 void Array::push_back(const Variant &value) {
 	sys_array_ops(Array_Op::PUSH_BACK, m_idx, 0, (Variant *)&value);
@@ -53,8 +53,7 @@ Variant Array::operator[](int idx) const {
 }
 
 int Array::size() const {
-	sys_array_size(m_idx);
-	return 0;
+	return sys_array_size(m_idx);
 }
 
 Array::Array(unsigned size) {
@@ -66,27 +65,4 @@ Array::Array(unsigned size) {
 Array::Array(const std::vector<Variant> &values) {
 	Variant v = Variant::from_array(values);
 	this->m_idx = v.get_internal_index();
-}
-
-Array::Array(const Array &other) {
-	m_idx = other.m_idx;
-}
-
-Array::Array(Array &&other) {
-	m_idx = other.m_idx;
-	// Invalidate the other array?
-}
-
-Array::~Array() {
-	// Do nothing, as we don't own the array?
-}
-
-Array &Array::operator=(const Array &other) {
-	m_idx = other.m_idx;
-	return *this;
-}
-
-Array &Array::operator=(Array &&other) {
-	m_idx = other.m_idx;
-	return *this;
 }

--- a/program/cpp/api/array.hpp
+++ b/program/cpp/api/array.hpp
@@ -5,14 +5,10 @@
 class ArrayIterator;
 
 struct Array {
-	Array(unsigned size = 0);
+	constexpr Array() {} // DON'T TOUCH
+	Array(unsigned size);
 	Array(const std::vector<Variant> &values);
-	Array(const Array &other);
-	Array(Array &&other);
-	~Array();
-
-	Array &operator=(const Array &other);
-	Array &operator=(Array &&other);
+	static Array Create(unsigned size = 0) { return Array(size); }
 
 	operator Variant() const;
 

--- a/program/cpp/api/dictionary.cpp
+++ b/program/cpp/api/dictionary.cpp
@@ -35,31 +35,10 @@ void Dictionary::merge(const Dictionary &other) {
 	(void)sys_dict_ops(Dictionary_Op::MERGE, m_idx, &v, nullptr);
 }
 
-Dictionary::Dictionary() {
+Dictionary Dictionary::Create() {
 	Variant v;
 	sys_vcreate(&v, Variant::DICTIONARY, 0, nullptr);
-	this->m_idx = v.get_internal_index();
-}
-
-Dictionary::Dictionary(const Dictionary &other) {
-	m_idx = other.m_idx;
-}
-
-Dictionary::Dictionary(Dictionary &&other) {
-	m_idx = other.m_idx;
-	// Invalidate the other dictionary?
-}
-
-Dictionary::~Dictionary() {
-	// Do nothing, as we don't own the dictionary?
-}
-
-Dictionary &Dictionary::operator=(const Dictionary &other) {
-	m_idx = other.m_idx;
-	return *this;
-}
-
-Dictionary &Dictionary::operator=(Dictionary &&other) {
-	m_idx = other.m_idx;
-	return *this;
+	Dictionary d;
+	d.m_idx = v.get_internal_index();
+	return d;
 }

--- a/program/cpp/api/dictionary.hpp
+++ b/program/cpp/api/dictionary.hpp
@@ -4,13 +4,8 @@
 struct DictAccessor;
 
 struct Dictionary {
-	Dictionary();
-	Dictionary(const Dictionary &other);
-	Dictionary(Dictionary &&other);
-	~Dictionary();
-
-	Dictionary &operator=(const Dictionary &other);
-	Dictionary &operator=(Dictionary &&other);
+	constexpr Dictionary() {} // DON'T TOUCH
+	static Dictionary Create();
 
 	operator Variant() const;
 

--- a/program/cpp/api/node.hpp
+++ b/program/cpp/api/node.hpp
@@ -4,7 +4,7 @@
 struct Node : public Object {
 	/// @brief Construct a Node object from an existing in-scope Node object.
 	/// @param addr The address of the Node object.
-	Node(uint64_t addr) : Object{addr} {}
+	constexpr Node(uint64_t addr) : Object{addr} {}
 	Node(Object obj) : Object{obj.address()} {}
 
 	/// @brief Construct a Node object from a path.

--- a/program/cpp/api/node2d.hpp
+++ b/program/cpp/api/node2d.hpp
@@ -6,7 +6,7 @@
 struct Node2D : public Node {
 	/// @brief Construct a Node2D object from an existing in-scope Node object.
 	/// @param addr The address of the Node2D object.
-	Node2D(uint64_t addr) : Node(addr) {}
+	constexpr Node2D(uint64_t addr) : Node(addr) {}
 	Node2D(Object obj) : Node(obj) {}
 	Node2D(Node node) : Node(node) {}
 

--- a/program/cpp/api/node3d.hpp
+++ b/program/cpp/api/node3d.hpp
@@ -6,7 +6,7 @@
 struct Node3D : public Node {
 	/// @brief Construct a Node3D object from an existing in-scope Node object.
 	/// @param addr The address of the Node3D object.
-	Node3D(uint64_t addr) : Node(addr) {}
+	constexpr Node3D(uint64_t addr) : Node(addr) {}
 	Node3D(Object obj) : Node(obj) {}
 	Node3D(Node node) : Node(node) {}
 

--- a/program/cpp/api/object.hpp
+++ b/program/cpp/api/object.hpp
@@ -8,7 +8,7 @@ struct Object {
 
 	/// @brief Construct an Object object from an existing in-scope Object object.
 	/// @param addr The address of the Object object.
-	Object(uint64_t addr) : m_address{addr} {}
+	constexpr Object(uint64_t addr) : m_address{addr} {}
 
 	/// Call a method on the node.
 	/// @param method The method to call.

--- a/program/cpp/api/string.cpp
+++ b/program/cpp/api/string.cpp
@@ -37,27 +37,8 @@ int String::size() const {
 	return sys_string_size(m_idx);
 }
 
-String::String(std::string_view value) {
-	this->m_idx = sys_string_create(value.data(), value.size());
-}
-
-String::String(const String &other) {
-	m_idx = other.m_idx;
-}
-
-String::String(String &&other) {
-	m_idx = other.m_idx;
-	// Invalidate the other string?
-}
-
-String &String::operator=(const String &other) {
-	m_idx = other.m_idx;
-	return *this;
-}
-
-String &String::operator=(String &&other) {
-	m_idx = other.m_idx;
-	return *this;
+unsigned String::Create(const char *data, size_t size) {
+	return sys_string_create(data, size);
 }
 
 std::string String::utf8() const {

--- a/program/cpp/api/string.hpp
+++ b/program/cpp/api/string.hpp
@@ -7,14 +7,10 @@
  * @brief String wrapper for Godot String.
  * Implemented by referencing and mutating a host-side String Variant.
  */
-struct String {
-	String(std::string_view value = "");
-	String(const String &other);
-	String(String &&other);
-	~String() = default;
-
-	String &operator=(const String &other);
-	String &operator=(String &&other);
+union String {
+	constexpr String() {} // DON'T TOUCH
+	String(std::string_view value)
+		: m_idx(Create(value.data(), value.size())) {}
 
 	// String operations
 	void append(const String &value);
@@ -40,8 +36,9 @@ struct String {
 	// String size
 	int size() const;
 
-	static String from_variant_index(unsigned idx) { String a; a.m_idx = idx; return a; }
+	static String from_variant_index(unsigned idx) { String a {}; a.m_idx = idx; return a; }
 	unsigned get_variant_index() const noexcept { return m_idx; }
+	static unsigned Create(const char *data, size_t size);
 
 private:
 	unsigned m_idx = -1;
@@ -61,16 +58,4 @@ inline String Variant::as_string() const {
 		api_throw("std::bad_cast", "Failed to cast Variant to String", this);
 	}
 	return String::from_variant_index(v.i);
-}
-
-inline String operator +(const String &lhs, const String &rhs) {
-	String s = lhs;
-	s.append(rhs);
-	return s;
-}
-
-inline String operator +(const String &lhs, std::string_view rhs) {
-	String s = lhs;
-	s.append(rhs);
-	return s;
 }

--- a/program/cpp/api/timer.cpp
+++ b/program/cpp/api/timer.cpp
@@ -1,9 +1,12 @@
 #include "timer.hpp"
 
+#include "object.hpp"
 #include "syscalls.h"
 
 using TimerEngineCallback = Variant (*)(Variant, Variant);
+using TimerEngineNativeCallback = Variant (*)(Object, Variant);
 MAKE_SYSCALL(ECALL_TIMER_PERIODIC, void, sys_timer_periodic, Timer::period_t, bool, TimerEngineCallback, void *, Variant *);
+MAKE_SYSCALL(ECALL_TIMER_PERIODIC, void, sys_timer_periodic_native, Timer::period_t, bool, TimerEngineNativeCallback, void *, Variant *);
 MAKE_SYSCALL(ECALL_TIMER_STOP, void, sys_timer_stop, unsigned);
 
 Variant Timer::create(period_t period, bool oneshot, TimerCallback callback) {
@@ -11,6 +14,17 @@ Variant Timer::create(period_t period, bool oneshot, TimerCallback callback) {
 	sys_timer_periodic(period, oneshot, [](Variant timer, Variant byte_array) -> Variant {
 		auto callback = byte_array.as_byte_array();
 		auto *timerfunc = (Timer::TimerCallback *)callback.data();
-		return (*timerfunc)(timer); }, &callback, &timer);
+		return (*timerfunc)(timer);
+	}, &callback, &timer);
+	return timer;
+}
+
+Variant Timer::create_native(period_t period, bool oneshot, TimerNativeCallback callback) {
+	Variant timer;
+	sys_timer_periodic_native(period, oneshot, [](Object timer, Variant byte_array) -> Variant {
+		auto callback = byte_array.as_byte_array();
+		auto *timerfunc = (Timer::TimerNativeCallback *)callback.data();
+		return (*timerfunc)(timer);
+	}, &callback, &timer);
 	return timer;
 }

--- a/program/cpp/api/timer.hpp
+++ b/program/cpp/api/timer.hpp
@@ -2,17 +2,26 @@
 
 #include "function.hpp"
 #include "variant.hpp"
+struct Object;
 
 struct Timer {
 	using period_t = double;
 	using TimerCallback = Function<Variant(Variant)>;
+	using TimerNativeCallback = Function<Variant(Object)>;
 
+	// For when all arguments are Variants
 	static Variant oneshot(period_t secs, TimerCallback callback);
 
 	static Variant periodic(period_t period, TimerCallback callback);
 
+	// For when native/register-based arguments are enabled
+	static Variant native_oneshot(period_t secs, TimerNativeCallback callback);
+
+	static Variant native_periodic(period_t period, TimerNativeCallback callback);
+
 private:
 	static Variant create(period_t p, bool oneshot, TimerCallback callback);
+	static Variant create_native(period_t p, bool oneshot, TimerNativeCallback callback);
 };
 
 inline Variant Timer::oneshot(period_t secs, TimerCallback callback) {
@@ -21,4 +30,12 @@ inline Variant Timer::oneshot(period_t secs, TimerCallback callback) {
 
 inline Variant Timer::periodic(period_t period, TimerCallback callback) {
 	return create(period, false, callback);
+}
+
+inline Variant Timer::native_oneshot(period_t secs, TimerNativeCallback callback) {
+	return create_native(secs, true, callback);
+}
+
+inline Variant Timer::native_periodic(period_t period, TimerNativeCallback callback) {
+	return create_native(period, false, callback);
 }

--- a/program/cpp/api/variant.hpp
+++ b/program/cpp/api/variant.hpp
@@ -25,7 +25,7 @@ struct is_u32string
 template<class T>
 struct is_stdstring : public std::is_same<T, std::basic_string<char>> {};
 
-struct Object; struct Node; struct Node2D; struct Node3D; struct Array; struct Dictionary; struct String;
+struct Object; struct Node; struct Node2D; struct Node3D; struct Array; struct Dictionary; union String;
 #include "vector.hpp"
 
 struct Variant
@@ -115,7 +115,7 @@ struct Variant
 		OP_MAX
 	};
 
-	Variant() = default;
+	Variant() { m_type = NIL; }
 	Variant(const Variant &other);
 	Variant(Variant &&other);
 	~Variant() {}
@@ -231,7 +231,7 @@ struct Variant
 private:
 	Type m_type = NIL;
 	union {
-		int64_t  i = 0;
+		int64_t  i;
 		bool     b;
 		double   f;
 		Vector2  v2;

--- a/program/cpp/build.sh
+++ b/program/cpp/build.sh
@@ -13,7 +13,7 @@ usage() {
 locally=false
 verbose=false
 current_version=5
-CPPFLAGS="-g -O2 -std=gnu++23 -DVERSION=$current_version"
+CPPFLAGS="-g -O2 -std=gnu++23 -DVERSION=$current_version -fno-stack-protector -fno-threadsafe-statics"
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in

--- a/src/sandbox.h
+++ b/src/sandbox.h
@@ -80,6 +80,13 @@ public:
 	Variant vmcallable(String function, Array args);
 	Variant vmcallable_address(uint64_t address, Array args);
 
+	/// @brief Set whether to prefer register values for VM function calls.
+	/// @param use_native_args True to prefer register values, false to prefer Variant values.
+	void set_use_native_args(bool use_native_args) { m_use_native_args = use_native_args; }
+	/// @brief Get whether to prefer register values for VM function calls.
+	/// @return True if register values are preferred, false if Variant values are preferred.
+	bool get_use_native_args() const { return m_use_native_args; }
+
 	// -= Sandbox Properties =-
 
 	uint32_t get_max_refs() const { return m_max_refs; }
@@ -227,6 +234,7 @@ private:
 	void print_backtrace(gaddr_t);
 	void initialize_syscalls();
 	GuestVariant *setup_arguments(gaddr_t &sp, const Variant **args, int argc);
+	void setup_arguments_native(gaddr_t arrayDataPtr, GuestVariant *v, const Variant **args, int argc);
 
 	Ref<ELFScript> m_program_data;
 	machine_t *m_machine = nullptr;
@@ -241,6 +249,7 @@ private:
 	bool m_last_newline = false;
 	uint8_t m_throttled = 0;
 	uint8_t m_level = 0;
+	bool m_use_native_args = false;
 
 	// Stats
 	unsigned m_budget_overruns = 0;

--- a/src/sandbox_functions.cpp
+++ b/src/sandbox_functions.cpp
@@ -16,6 +16,7 @@ static const std::unordered_set<std::string_view> exclude_functions{
 	"sys_obj_callp",
 	"sys_obj",
 	"sys_get_node",
+	"sys_node_create",
 	"sys_node",
 	"sys_node2d",
 	"sys_node3d",
@@ -30,6 +31,7 @@ static const std::unordered_set<std::string_view> exclude_functions{
 	"sys_string_ops",
 	"sys_string_size",
 	"sys_timer_periodic",
+	"sys_timer_periodic_native",
 	"sys_timer_stop",
 
 	"main",

--- a/src/sandbox_project_settings.cpp
+++ b/src/sandbox_project_settings.cpp
@@ -5,9 +5,12 @@
 
 using namespace godot;
 
-constexpr char DOCKER_PATH[] = "editor/script/docker";
+static constexpr char DOCKER_PATH[] = "editor/script/docker";
+static constexpr char DOCKER_PATH_HINT[] = "Path to the Docker executable";
+static constexpr char NATIVE_TYPES[] = "editor/script/native_types";
+static constexpr char NATIVE_TYPES_HINT[] = "Use native types when calling VM functions where possible";
 
-void register_setting(
+static void register_setting(
 		const String &p_name,
 		const Variant &p_value,
 		bool p_needs_restart,
@@ -41,20 +44,22 @@ void register_setting(
 void register_setting_plain(
 		const String &p_name,
 		const Variant &p_value,
+		const String &p_hint_string = "",
 		bool p_needs_restart = false) {
-	register_setting(p_name, p_value, p_needs_restart, PROPERTY_HINT_NONE, {});
+	register_setting(p_name, p_value, p_needs_restart, PROPERTY_HINT_NONE, p_hint_string);
 }
 
 void SandboxProjectSettings::register_settings() {
 #ifdef WIN32
-	register_setting_plain(DOCKER_PATH, "C:\\Program Files\\Docker\\Docker\\bin\\", true);
+	register_setting_plain(DOCKER_PATH, "C:\\Program Files\\Docker\\Docker\\bin\\", DOCKER_PATH_HINT, true);
 #else
-	register_setting_plain(DOCKER_PATH, "docker");
+	register_setting_plain(DOCKER_PATH, "docker", DOCKER_PATH_HINT, true);
 #endif
+	register_setting_plain(NATIVE_TYPES, false, NATIVE_TYPES_HINT, false);
 }
 
 template <typename TType>
-TType get_setting(const char *p_setting) {
+static TType get_setting(const char *p_setting) {
 	const ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	const Variant setting_value = project_settings->get_setting_with_override(p_setting);
 	const Variant::Type setting_type = setting_value.get_type();
@@ -67,4 +72,8 @@ TType get_setting(const char *p_setting) {
 
 String SandboxProjectSettings::get_docker_path() {
 	return get_setting<String>(DOCKER_PATH);
+}
+
+bool SandboxProjectSettings::use_native_types() {
+	return get_setting<bool>(NATIVE_TYPES);
 }

--- a/src/sandbox_project_settings.h
+++ b/src/sandbox_project_settings.h
@@ -9,4 +9,6 @@ public:
 	static void register_settings();
 
 	static String get_docker_path();
+
+	static bool use_native_types();
 };

--- a/tests/.gutconfig.json
+++ b/tests/.gutconfig.json
@@ -1,0 +1,18 @@
+{
+	"dirs": [
+		"res://tests/"
+	],
+	"double_strategy": "partial",
+	"ignore_pause": false,
+	"include_subdirs": true,
+	"inner_class": "",
+	"log_level": 3,
+	"opacity": 100,
+	"prefix": "test_",
+	"selected": "",
+	"should_exit": true,
+	"should_maximize": true,
+	"suffix": ".gd",
+	"tests": [],
+	"unit_test_name": ""
+}

--- a/tests/run_unittests.sh
+++ b/tests/run_unittests.sh
@@ -1,0 +1,3 @@
+GODOT=~/Godot_v4.3-stable_linux.x86_64
+
+$GODOT --path "$PWD" --headless -s addons/gut/gut_cmdln.gd

--- a/tests/tests/test_basic.cpp
+++ b/tests/tests/test_basic.cpp
@@ -4,6 +4,10 @@ extern "C" Variant public_function() {
 	return "Hello from the other side";
 }
 
+extern "C" Variant test_ping_pong(Variant arg) {
+	return arg;
+}
+
 extern "C" Variant test_dictionary(Variant dict) {
 	return Dictionary(dict)["1"];
 }

--- a/tests/tests/test_basic.gd
+++ b/tests/tests/test_basic.gd
@@ -6,6 +6,35 @@ func test_instantiation():
 	# Set the test program
 	s.set_program(Sandbox_TestsTests)
 
+	# Verify all basic types can be ping-ponged
+	var nil : Variant
+	assert_eq(s.vmcall("test_ping_pong", nil), nil) # Nil
+	assert_eq(s.vmcall("test_ping_pong", true), true) # Bool
+	assert_eq(s.vmcall("test_ping_pong", 1234), 1234) # Int
+	assert_eq(s.vmcall("test_ping_pong", 9876.0), 9876.0) # Float
+	assert_eq(s.vmcall("test_ping_pong", "9876.0"), "9876.0") # String
+	
+
+	# Array, Dictionary and String as references
+	var a_pp : Array
+	assert_same(s.vmcall("test_ping_pong", a_pp), a_pp)
+	var d_pp : Dictionary
+	assert_same(s.vmcall("test_ping_pong", d_pp), d_pp)
+	var s_pp : String = "12345"
+	assert_same(s.vmcall("test_ping_pong", s_pp), s_pp)
+	assert_eq(s_pp, "12345")
+	# Packed arrays
+	var pba_pp : PackedByteArray = [1, 2, 3, 4]
+	assert_same(s.vmcall("test_ping_pong", pba_pp), pba_pp)
+	var pfa32_pp : PackedFloat32Array = [1.0, 2.0, 3.0, 4.0]
+	assert_same(s.vmcall("test_ping_pong", pfa32_pp), pfa32_pp)
+	var pfa64_pp : PackedFloat64Array = [1.0, 2.0, 3.0, 4.0]
+	assert_same(s.vmcall("test_ping_pong", pfa64_pp), pfa64_pp)
+
+	# Callables
+	var cb : Callable = Callable(callable_function)
+	assert_same(s.vmcall("test_ping_pong", cb), cb)
+
 	# Verify that a basic function that returns a String works
 	assert_eq(s.vmcall("public_function"), "Hello from the other side")
 
@@ -15,3 +44,6 @@ func test_instantiation():
 	d["1"]["2"] = "3"
 	
 	assert_eq(s.vmcall("test_dictionary", d), d["1"])
+
+func callable_function():
+	return


### PR DESCRIPTION
Also, improve unittest by checking basic in/out of common variants
