### PR TITLE
Initial support for Zig scripting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ set(SOURCES
 	src/rust/resource_saver_rust.cpp
 	src/rust/script_rust.cpp
 	src/rust/script_language_rust.cpp
+	src/zig/resource_loader_zig.cpp
+	src/zig/resource_saver_zig.cpp
+	src/zig/script_zig.cpp
+	src/zig/script_language_zig.cpp
 	src/docker.cpp
 	src/godot/script_instance.cpp
 	src/guest_variant.cpp

--- a/SConstruct
+++ b/SConstruct
@@ -11,7 +11,7 @@ env.Append(CPPDEFINES = ['RISCV_SYSCALLS_MAX=600', 'RISCV_BRK_MEMORY_SIZE=0x1000
 env.Prepend(CPPPATH=["ext/libriscv/lib"])
 env.Append(CPPPATH=["src/", "."])
 
-sources = [Glob("src/*.cpp"), Glob("src/cpp/*.cpp"), Glob("src/rust/*.cpp"), Glob("src/elf/*.cpp"), Glob("src/godot/*.cpp"), ["src/tests/dummy_assault.cpp"]]
+sources = [Glob("src/*.cpp"), Glob("src/cpp/*.cpp"), Glob("src/rust/*.cpp"), Glob("src/zig/*.cpp"), Glob("src/elf/*.cpp"), Glob("src/godot/*.cpp"), ["src/tests/dummy_assault.cpp"]]
 
 librisc_sources = [
 	# threaded fast-path:

--- a/program/zig/.gitignore
+++ b/program/zig/.gitignore
@@ -1,0 +1,3 @@
+# Rust ignore
+Cargo.lock
+target/

--- a/program/zig/Dockerfile
+++ b/program/zig/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:24.04
+
+RUN apt-get -qq update && \
+	apt-get install -y -q \
+	curl xz-utils lld
+
+# Install Zig
+# https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+RUN curl -L https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz -o zig.tar.xz
+# zig-linux-x86_64-0.13.0
+RUN tar -xf zig.tar.xz && rm zig.tar.xz && mv zig-linux-x86_64-0.13.0 /usr/zig
+
+# TODO: API in /usr/api
+
+WORKDIR /usr/src
+# Copy API files
+RUN mkdir -p /usr/api
+COPY build.sh api/* /usr/api/
+
+# Make the container a background process
+CMD ["/bin/bash", "-c", "tail -f /dev/null"]

--- a/program/zig/build.sh
+++ b/program/zig/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+usage() {
+	echo "Usage: $0 [--api] [-o output] -- [input...]"
+	echo "  --api        Instead of compiling, copy the API files to the output."
+	echo "   -o output   Compile sources into an output ELF file, including API and inputs."
+	echo "  --local      Compile as if locally (outside Docker), using the local API files."
+	echo "  --version    Print the current version of the API."
+	echo "   -v          Verbose output."
+	echo "  --           Separate options from input files."
+	exit 1
+}
+
+locally=false
+verbose=false
+current_version=1
+
+while [[ "$#" -gt 0 ]]; do
+	case $1 in
+		--api) cp -r /usr/api $1; exit ;;
+		-o) shift; output="$1"; shift; break ;;
+		--local) locally=true; shift ;;
+		--version) shift; echo "$current_version"; exit ;;
+		-v) verbose=true; shift ;;
+		--) shift; break ;;
+		*) usage ;;
+	esac
+done
+
+if [ -z "$output" ]; then
+	usage
+fi
+
+DIR="$(dirname "${output}")"
+FILE="$(basename "${output}")"
+time /usr/zig/zig build-exe -O ReleaseSmall -fno-strip -flld -target riscv64-linux $@ --name $FILE
+mv $FILE $output
+rm -f $FILE.o

--- a/program/zig/container_build.sh
+++ b/program/zig/container_build.sh
@@ -1,0 +1,1 @@
+docker build -t riscv64-zig .

--- a/program/zig/start.sh
+++ b/program/zig/start.sh
@@ -1,0 +1,1 @@
+docker run --name godot-zig-compiler -dv .:/usr/src riscv64-zig

--- a/program/zig/stop_and_remove.sh
+++ b/program/zig/stop_and_remove.sh
@@ -1,0 +1,2 @@
+docker stop -t1 godot-zig-compiler
+docker rm godot-zig-compiler

--- a/src/elf/script_instance.cpp
+++ b/src/elf/script_instance.cpp
@@ -2,6 +2,7 @@
 
 #include "../cpp/script_cpp.h"
 #include "../rust/script_rust.h"
+#include "../zig/script_zig.h"
 #include "../sandbox.h"
 #include "script_elf.h"
 #include "script_instance_helper.h"
@@ -38,6 +39,18 @@ static void handle_language_warnings(Array &warnings, const Ref<ELFScript> &scri
 			const int script_version = script->get_elf_api_version();
 			if (script_version < docker_version) {
 				String w = "Rust API version is newer (" + String::num_int64(script_version) + " vs " + String::num_int64(docker_version) + "), please rebuild the program";
+				warnings.push_back(std::move(w));
+			}
+		}
+	} else if (language == "Zig") {
+		// Compare Zig version against Docker version
+		const int docker_version = ZigScript::DockerContainerVersion();
+		if (docker_version < 0) {
+			warnings.push_back("Zig Docker container not found");
+		} else {
+			const int script_version = script->get_elf_api_version();
+			if (script_version < docker_version) {
+				String w = "Zig API version is newer (" + String::num_int64(script_version) + " vs " + String::num_int64(docker_version) + "), please rebuild the program";
 				warnings.push_back(std::move(w));
 			}
 		}

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -21,6 +21,10 @@
 #include "rust/script_rust.h"
 #include "sandbox.h"
 #include "sandbox_project_settings.h"
+#include "zig/resource_loader_zig.h"
+#include "zig/resource_saver_zig.h"
+#include "zig/script_language_zig.h"
+#include "zig/script_zig.h"
 
 using namespace godot;
 
@@ -50,6 +54,10 @@ static void initialize_riscv_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<ResourceFormatLoaderRust>();
 	ClassDB::register_class<ResourceFormatSaverRust>();
 	ClassDB::register_class<RustScriptLanguage>();
+	ClassDB::register_class<ZigScript>();
+	ClassDB::register_class<ResourceFormatLoaderZig>();
+	ClassDB::register_class<ResourceFormatSaverZig>();
+	ClassDB::register_class<ZigScriptLanguage>();
 	elf_loader.instantiate();
 	elf_saver.instantiate();
 	elf_language = memnew(ELFScriptLanguage);
@@ -62,6 +70,9 @@ static void initialize_riscv_module(ModuleInitializationLevel p_level) {
 	RustScriptLanguage::init();
 	ResourceFormatLoaderRust::init();
 	ResourceFormatSaverRust::init();
+	ZigScriptLanguage::init();
+	ResourceFormatLoaderZig::init();
+	ResourceFormatSaverZig::init();
 	SandboxProjectSettings::register_settings();
 }
 
@@ -80,6 +91,8 @@ static void uninitialize_riscv_module(ModuleInitializationLevel p_level) {
 	ResourceFormatSaverCPP::deinit();
 	ResourceFormatLoaderRust::deinit();
 	ResourceFormatSaverRust::deinit();
+	ResourceFormatLoaderZig::deinit();
+	ResourceFormatSaverZig::deinit();
 }
 
 extern "C" {

--- a/src/sandbox_functions.cpp
+++ b/src/sandbox_functions.cpp
@@ -1214,6 +1214,14 @@ Sandbox::BinaryInfo Sandbox::get_program_info_from_binary(const PackedByteArray 
 					result.version = std::stoi(std::string(comment.substr(version + 5)));
 				}
 				break;
+			} else if (comment.find("Godot Zig") != std::string::npos) {
+				// Zig: "Godot Zig API v1"
+				result.language = "Zig";
+				auto version = comment.find("API v");
+				if (version != std::string::npos) {
+					result.version = std::stoi(std::string(comment.substr(version + 5)));
+				}
+				break;
 			}
 		}
 		//printf("Detected language: %s, version: %d\n", result.language.utf8().ptr(), result.version);

--- a/src/sandbox_syscalls.cpp
+++ b/src/sandbox_syscalls.cpp
@@ -1,5 +1,5 @@
-#include "syscalls.h"
 #include "guest_datatypes.h"
+#include "syscalls.h"
 
 #include <cmath>
 #include <godot_cpp/classes/engine.hpp>

--- a/src/zig/resource_loader_zig.cpp
+++ b/src/zig/resource_loader_zig.cpp
@@ -1,0 +1,36 @@
+#include "resource_loader_zig.h"
+#include "script_zig.h"
+#include <godot_cpp/classes/file_access.hpp>
+
+static Ref<ResourceFormatLoaderZig> zig_loader;
+
+void ResourceFormatLoaderZig::init() {
+	zig_loader.instantiate();
+	ResourceLoader::get_singleton()->add_resource_format_loader(zig_loader);
+}
+
+void ResourceFormatLoaderZig::deinit() {
+	ResourceLoader::get_singleton()->remove_resource_format_loader(zig_loader);
+	zig_loader.unref();
+}
+
+Variant ResourceFormatLoaderZig::_load(const String &p_path, const String &original_path, bool use_sub_threads, int32_t cache_mode) const {
+	Ref<ZigScript> model = memnew(ZigScript);
+	model->_set_source_code(FileAccess::get_file_as_string(p_path));
+	return model;
+}
+PackedStringArray ResourceFormatLoaderZig::_get_recognized_extensions() const {
+	PackedStringArray array;
+	array.push_back("zig");
+	return array;
+}
+bool ResourceFormatLoaderZig::_handles_type(const StringName &type) const {
+	String type_str = type;
+	return type_str == "ZigScript" || type_str == "Script";
+}
+String ResourceFormatLoaderZig::_get_resource_type(const String &p_path) const {
+	if (p_path.get_extension() == "zig") {
+		return "ZigScript";
+	}
+	return "";
+}

--- a/src/zig/resource_loader_zig.h
+++ b/src/zig/resource_loader_zig.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <godot_cpp/classes/resource_format_loader.hpp>
+#include <godot_cpp/classes/resource_loader.hpp>
+
+using namespace godot;
+
+class ResourceFormatLoaderZig : public ResourceFormatLoader {
+	GDCLASS(ResourceFormatLoaderZig, ResourceFormatLoader);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	static void init();
+	static void deinit();
+	virtual Variant _load(const String &path, const String &original_path, bool use_sub_threads, int32_t cache_mode) const override;
+	virtual PackedStringArray _get_recognized_extensions() const override;
+	virtual bool _handles_type(const StringName &type) const override;
+	virtual String _get_resource_type(const String &p_path) const override;
+};

--- a/src/zig/resource_saver_zig.cpp
+++ b/src/zig/resource_saver_zig.cpp
@@ -1,0 +1,90 @@
+#include "resource_saver_zig.h"
+#include "../elf/script_elf.h"
+#include "../elf/script_language_elf.h"
+#include "../register_types.h"
+#include "../sandbox_project_settings.h"
+#include "script_zig.h"
+#include <godot_cpp/classes/editor_file_system.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_settings.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/script.hpp>
+#include <godot_cpp/classes/script_editor.hpp>
+#include <godot_cpp/classes/script_editor_base.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+static Ref<ResourceFormatSaverZig> zig_saver;
+static constexpr bool VERBOSE_CMD = false;
+
+void ResourceFormatSaverZig::init() {
+	zig_saver.instantiate();
+	ResourceSaver::get_singleton()->add_resource_format_saver(zig_saver);
+}
+
+void ResourceFormatSaverZig::deinit() {
+	ResourceSaver::get_singleton()->remove_resource_format_saver(zig_saver);
+	zig_saver.unref();
+}
+
+Error ResourceFormatSaverZig::_save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+	ZigScript *script = Object::cast_to<ZigScript>(p_resource.ptr());
+	if (script != nullptr) {
+		Ref<FileAccess> handle = FileAccess::open(p_path, FileAccess::ModeFlags::WRITE);
+		if (handle.is_valid()) {
+			handle->store_string(script->_get_source_code());
+			handle->close();
+			// Get the absolute path without the file name
+			String path = handle->get_path().get_base_dir().replace("res://", "") + "/";
+			String inpname = path + "*.zig";
+			String foldername = Docker::GetFolderName(handle->get_path().get_base_dir());
+			String outname = path + foldername + String(".elf");
+
+			// Lazily start the docker container
+			ZigScript::DockerContainerStart();
+
+			auto builder = [inpname = std::move(inpname), outname = std::move(outname)] {
+				// Invoke docker to compile the file
+				Array output;
+				ZigScript::DockerContainerExecute({ "/usr/api/build.sh", "-o", outname, inpname }, output);
+				if (!output.is_empty() && !output[0].operator String().is_empty()) {
+					for (int i = 0; i < output.size(); i++) {
+						String line = output[i].operator String();
+						if constexpr (VERBOSE_CMD)
+							ERR_PRINT(line);
+						WARN_PRINT(line);
+					}
+				}
+			};
+			builder();
+			// EditorInterface::get_singleton()->get_editor_settings()->set("text_editor/behavior/files/auto_reload_scripts_on_external_change", true);
+			EditorInterface::get_singleton()->get_resource_filesystem()->scan();
+			TypedArray<Script> open_scripts = EditorInterface::get_singleton()->get_script_editor()->get_open_scripts();
+			for (int i = 0; i < open_scripts.size(); i++) {
+				ELFScript *elf_script = Object::cast_to<ELFScript>(open_scripts[i]);
+				if (elf_script) {
+					elf_script->reload(false);
+					elf_script->emit_changed();
+				}
+			}
+			return Error::OK;
+		} else {
+			return Error::ERR_FILE_CANT_OPEN;
+		}
+	}
+	return Error::ERR_SCRIPT_FAILED;
+}
+Error ResourceFormatSaverZig::_set_uid(const String &p_path, int64_t p_uid) {
+	return Error::OK;
+}
+bool ResourceFormatSaverZig::_recognize(const Ref<Resource> &p_resource) const {
+	return Object::cast_to<ZigScript>(p_resource.ptr()) != nullptr;
+}
+PackedStringArray ResourceFormatSaverZig::_get_recognized_extensions(const Ref<Resource> &p_resource) const {
+	PackedStringArray array;
+	array.push_back("zig");
+	return array;
+}
+bool ResourceFormatSaverZig::_recognize_path(const Ref<Resource> &p_resource, const String &p_path) const {
+	return Object::cast_to<ZigScript>(p_resource.ptr()) != nullptr;
+}

--- a/src/zig/resource_saver_zig.h
+++ b/src/zig/resource_saver_zig.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <godot_cpp/classes/resource_format_saver.hpp>
+#include <godot_cpp/classes/resource_saver.hpp>
+
+using namespace godot;
+
+class ResourceFormatSaverZig : public ResourceFormatSaver {
+	GDCLASS(ResourceFormatSaverZig, ResourceFormatSaver);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	static void init();
+	static void deinit();
+	virtual Error _save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) override;
+	virtual Error _set_uid(const String &p_path, int64_t p_uid) override;
+	virtual bool _recognize(const Ref<Resource> &p_resource) const override;
+	virtual PackedStringArray _get_recognized_extensions(const Ref<Resource> &p_resource) const override;
+	virtual bool _recognize_path(const Ref<Resource> &p_resource, const String &p_path) const override;
+};

--- a/src/zig/script_language_zig.cpp
+++ b/src/zig/script_language_zig.cpp
@@ -1,0 +1,197 @@
+#include "script_language_zig.h"
+#include "script_zig.h"
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/resource_loader.hpp>
+#include <godot_cpp/classes/texture2d.hpp>
+#include <godot_cpp/classes/theme.hpp>
+#include <string>
+#include <unordered_set>
+static constexpr const char *icon_path = "res://addons/godot_sandbox/ZigScript.svg";
+
+static ZigScriptLanguage *zig_language;
+
+void ZigScriptLanguage::init() {
+	zig_language = memnew(ZigScriptLanguage);
+	Engine::get_singleton()->register_script_language(zig_language);
+}
+
+ZigScriptLanguage *ZigScriptLanguage::get_singleton() {
+	return zig_language;
+}
+
+String ZigScriptLanguage::_get_name() const {
+	return "ZigScript";
+}
+void ZigScriptLanguage::_init() {}
+String ZigScriptLanguage::_get_type() const {
+	return "ZigScript";
+}
+String ZigScriptLanguage::_get_extension() const {
+	return "zig";
+}
+void ZigScriptLanguage::_finish() {}
+PackedStringArray ZigScriptLanguage::_get_reserved_words() const {
+	static const PackedStringArray reserved_words{
+		"addrspace", "align", "and", "asm", "async", "await", "break", "catch", "comptime", "const", "continue", "defer", "else", "enum", "errdefer", "error", "export", "extern", "for", "if", "inline", "noalias", "noinline", "nosuspend", "opaque", "or", "orelse", "packed", "anyframe", "pub", "resume", "return", "linksection", "callconv", "struct", "suspend", "switch", "test", "threadlocal", "try", "union", "unreachable", "usingnamespace", "var", "volatile", "allowzero", "while", "anytype", "fn"
+	};
+	return reserved_words;
+}
+bool ZigScriptLanguage::_is_control_flow_keyword(const String &p_keyword) const {
+	static const std::unordered_set<std::string> control_flow_keywords{
+		"if", "else", "switch", "case", "default", "while", "loop", "for", "break", "continue", "return", "goto", "resume", "suspend", "defer", "errdefer", "try", "catch", "async", "await"
+	};
+	return control_flow_keywords.find(p_keyword.utf8().get_data()) != control_flow_keywords.end();
+}
+PackedStringArray ZigScriptLanguage::_get_comment_delimiters() const {
+	PackedStringArray comment_delimiters;
+	comment_delimiters.push_back("/* */");
+	comment_delimiters.push_back("//");
+	return comment_delimiters;
+}
+PackedStringArray ZigScriptLanguage::_get_doc_comment_delimiters() const {
+	PackedStringArray doc_comment_delimiters;
+	doc_comment_delimiters.push_back("///");
+	doc_comment_delimiters.push_back("/** */");
+	return doc_comment_delimiters;
+}
+PackedStringArray ZigScriptLanguage::_get_string_delimiters() const {
+	PackedStringArray string_delimiters;
+	string_delimiters.push_back("' '");
+	string_delimiters.push_back("\" \"");
+	return string_delimiters;
+}
+Ref<Script> ZigScriptLanguage::_make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const {
+	ZigScript *script = memnew(ZigScript);
+	return Ref<Script>(script);
+}
+TypedArray<Dictionary> ZigScriptLanguage::_get_built_in_templates(const StringName &p_object) const {
+	return TypedArray<Dictionary>();
+}
+bool ZigScriptLanguage::_is_using_templates() {
+	return false;
+}
+Dictionary ZigScriptLanguage::_validate(const String &p_script, const String &p_path, bool p_validate_functions, bool p_validate_errors, bool p_validate_warnings, bool p_validate_safe_lines) const {
+	return Dictionary();
+}
+String ZigScriptLanguage::_validate_path(const String &p_path) const {
+	return String();
+}
+Object *ZigScriptLanguage::_create_script() const {
+	ZigScript *script = memnew(ZigScript);
+	return script;
+}
+bool ZigScriptLanguage::_has_named_classes() const {
+	return false;
+}
+bool ZigScriptLanguage::_supports_builtin_mode() const {
+	return false;
+}
+bool ZigScriptLanguage::_supports_documentation() const {
+	return false;
+}
+bool ZigScriptLanguage::_can_inherit_from_file() const {
+	return false;
+}
+int32_t ZigScriptLanguage::_find_function(const String &p_function, const String &p_code) const {
+	return -1;
+}
+String ZigScriptLanguage::_make_function(const String &p_class_name, const String &p_function_name, const PackedStringArray &p_function_args) const {
+	return String();
+}
+Error ZigScriptLanguage::_open_in_external_editor(const Ref<Script> &p_script, int32_t p_line, int32_t p_column) {
+	return Error::OK;
+}
+bool ZigScriptLanguage::_overrides_external_editor() {
+	return false;
+}
+Dictionary ZigScriptLanguage::_complete_code(const String &p_code, const String &p_path, Object *p_owner) const {
+	return Dictionary();
+}
+Dictionary ZigScriptLanguage::_lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner) const {
+	return Dictionary();
+}
+String ZigScriptLanguage::_auto_indent_code(const String &p_code, int32_t p_from_line, int32_t p_to_line) const {
+	return String();
+}
+void ZigScriptLanguage::_add_global_constant(const StringName &p_name, const Variant &p_value) {}
+void ZigScriptLanguage::_add_named_global_constant(const StringName &p_name, const Variant &p_value) {}
+void ZigScriptLanguage::_remove_named_global_constant(const StringName &p_name) {}
+void ZigScriptLanguage::_thread_enter() {}
+void ZigScriptLanguage::_thread_exit() {}
+String ZigScriptLanguage::_debug_get_error() const {
+	return String();
+}
+int32_t ZigScriptLanguage::_debug_get_stack_level_count() const {
+	return 0;
+}
+int32_t ZigScriptLanguage::_debug_get_stack_level_line(int32_t p_level) const {
+	return 0;
+}
+String ZigScriptLanguage::_debug_get_stack_level_function(int32_t p_level) const {
+	return String();
+}
+Dictionary ZigScriptLanguage::_debug_get_stack_level_locals(int32_t p_level, int32_t p_max_subitems, int32_t p_max_depth) {
+	return Dictionary();
+}
+Dictionary ZigScriptLanguage::_debug_get_stack_level_members(int32_t p_level, int32_t p_max_subitems, int32_t p_max_depth) {
+	return Dictionary();
+}
+void *ZigScriptLanguage::_debug_get_stack_level_instance(int32_t p_level) {
+	return nullptr;
+}
+Dictionary ZigScriptLanguage::_debug_get_globals(int32_t p_max_subitems, int32_t p_max_depth) {
+	return Dictionary();
+}
+String ZigScriptLanguage::_debug_parse_stack_level_expression(int32_t p_level, const String &p_expression, int32_t p_max_subitems, int32_t p_max_depth) {
+	return String();
+}
+TypedArray<Dictionary> ZigScriptLanguage::_debug_get_current_stack_info() {
+	return TypedArray<Dictionary>();
+}
+void ZigScriptLanguage::_reload_all_scripts() {}
+void ZigScriptLanguage::_reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) {}
+PackedStringArray ZigScriptLanguage::_get_recognized_extensions() const {
+	PackedStringArray array;
+	array.push_back("zig");
+	return array;
+}
+TypedArray<Dictionary> ZigScriptLanguage::_get_public_functions() const {
+	return TypedArray<Dictionary>();
+}
+Dictionary ZigScriptLanguage::_get_public_constants() const {
+	return Dictionary();
+}
+TypedArray<Dictionary> ZigScriptLanguage::_get_public_annotations() const {
+	return TypedArray<Dictionary>();
+}
+void ZigScriptLanguage::_profiling_start() {}
+void ZigScriptLanguage::_profiling_stop() {}
+int32_t ZigScriptLanguage::_profiling_get_accumulated_data(ScriptLanguageExtensionProfilingInfo *p_info_array, int32_t p_info_max) {
+	return 0;
+}
+int32_t ZigScriptLanguage::_profiling_get_frame_data(ScriptLanguageExtensionProfilingInfo *p_info_array, int32_t p_info_max) {
+	return 0;
+}
+void ZigScriptLanguage::_frame() {
+	static bool icon_registered = false;
+	if (!icon_registered) {
+		icon_registered = true;
+		// Manually register language icon
+		if (Engine::get_singleton()->is_editor_hint() && FileAccess::file_exists(icon_path)) {
+			EditorInterface *editor_interface = EditorInterface::get_singleton();
+			Ref<Theme> editor_theme = editor_interface->get_editor_theme();
+			ResourceLoader *resource_loader = ResourceLoader::get_singleton();
+			Ref<Texture2D> tex = resource_loader->load(icon_path);
+
+			editor_theme->set_icon("ZigScript", "EditorIcons", tex);
+		}
+	}
+}
+bool ZigScriptLanguage::_handles_global_class_type(const String &p_type) const {
+	return p_type == "ZigScript";
+}
+Dictionary ZigScriptLanguage::_get_global_class_name(const String &p_path) const {
+	return Dictionary();
+}

--- a/src/zig/script_language_zig.h
+++ b/src/zig/script_language_zig.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <godot_cpp/classes/script.hpp>
+#include <godot_cpp/classes/script_language_extension.hpp>
+
+using namespace godot;
+
+class ZigScriptLanguage : public ScriptLanguageExtension {
+	GDCLASS(ZigScriptLanguage, ScriptLanguageExtension);
+
+protected:
+	static void _bind_methods() {}
+	String file;
+
+public:
+	static void init();
+	static ZigScriptLanguage *get_singleton();
+
+	virtual String _get_name() const override;
+	virtual void _init() override;
+	virtual String _get_type() const override;
+	virtual String _get_extension() const override;
+	virtual void _finish() override;
+	virtual PackedStringArray _get_reserved_words() const override;
+	virtual bool _is_control_flow_keyword(const String &p_keyword) const override;
+	virtual PackedStringArray _get_comment_delimiters() const override;
+	virtual PackedStringArray _get_doc_comment_delimiters() const override;
+	virtual PackedStringArray _get_string_delimiters() const override;
+	virtual Ref<Script> _make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
+	virtual TypedArray<Dictionary> _get_built_in_templates(const StringName &p_object) const override;
+	virtual bool _is_using_templates() override;
+	virtual Dictionary _validate(const String &p_script, const String &p_path, bool p_validate_functions, bool p_validate_errors, bool p_validate_warnings, bool p_validate_safe_lines) const override;
+	virtual String _validate_path(const String &p_path) const override;
+	virtual Object *_create_script() const override;
+	virtual bool _has_named_classes() const override;
+	virtual bool _supports_builtin_mode() const override;
+	virtual bool _supports_documentation() const override;
+	virtual bool _can_inherit_from_file() const override;
+	virtual int32_t _find_function(const String &p_function, const String &p_code) const override;
+	virtual String _make_function(const String &p_class_name, const String &p_function_name, const PackedStringArray &p_function_args) const override;
+	virtual Error _open_in_external_editor(const Ref<Script> &p_script, int32_t p_line, int32_t p_column) override;
+	virtual bool _overrides_external_editor() override;
+	virtual Dictionary _complete_code(const String &p_code, const String &p_path, Object *p_owner) const override;
+	virtual Dictionary _lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner) const override;
+	virtual String _auto_indent_code(const String &p_code, int32_t p_from_line, int32_t p_to_line) const override;
+	virtual void _add_global_constant(const StringName &p_name, const Variant &p_value) override;
+	virtual void _add_named_global_constant(const StringName &p_name, const Variant &p_value) override;
+	virtual void _remove_named_global_constant(const StringName &p_name) override;
+	virtual void _thread_enter() override;
+	virtual void _thread_exit() override;
+	virtual String _debug_get_error() const override;
+	virtual int32_t _debug_get_stack_level_count() const override;
+	virtual int32_t _debug_get_stack_level_line(int32_t p_level) const override;
+	virtual String _debug_get_stack_level_function(int32_t p_level) const override;
+	virtual Dictionary _debug_get_stack_level_locals(int32_t p_level, int32_t p_max_subitems, int32_t p_max_depth) override;
+	virtual Dictionary _debug_get_stack_level_members(int32_t p_level, int32_t p_max_subitems, int32_t p_max_depth) override;
+	virtual void *_debug_get_stack_level_instance(int32_t p_level) override;
+	virtual Dictionary _debug_get_globals(int32_t p_max_subitems, int32_t p_max_depth) override;
+	virtual String _debug_parse_stack_level_expression(int32_t p_level, const String &p_expression, int32_t p_max_subitems, int32_t p_max_depth) override;
+	virtual TypedArray<Dictionary> _debug_get_current_stack_info() override;
+	virtual void _reload_all_scripts() override;
+	virtual void _reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) override;
+	virtual PackedStringArray _get_recognized_extensions() const override;
+	virtual TypedArray<Dictionary> _get_public_functions() const override;
+	virtual Dictionary _get_public_constants() const override;
+	virtual TypedArray<Dictionary> _get_public_annotations() const override;
+	virtual void _profiling_start() override;
+	virtual void _profiling_stop() override;
+	virtual int32_t _profiling_get_accumulated_data(ScriptLanguageExtensionProfilingInfo *p_info_array, int32_t p_info_max) override;
+	virtual int32_t _profiling_get_frame_data(ScriptLanguageExtensionProfilingInfo *p_info_array, int32_t p_info_max) override;
+	virtual void _frame() override;
+	virtual bool _handles_global_class_type(const String &p_type) const override;
+	virtual Dictionary _get_global_class_name(const String &p_path) const override;
+
+	ZigScriptLanguage() {}
+	~ZigScriptLanguage() {}
+};

--- a/src/zig/script_zig.cpp
+++ b/src/zig/script_zig.cpp
@@ -1,0 +1,113 @@
+#include "script_zig.h"
+
+#include "script_language_zig.h"
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/resource_loader.hpp>
+
+bool ZigScript::_editor_can_reload_from_file() {
+	return true;
+}
+void ZigScript::_placeholder_erased(void *p_placeholder) {}
+bool ZigScript::_can_instantiate() const {
+	return false;
+}
+Ref<Script> ZigScript::_get_base_script() const {
+	return Ref<Script>();
+}
+StringName ZigScript::_get_global_name() const {
+	return StringName();
+}
+bool ZigScript::_inherits_script(const Ref<Script> &p_script) const {
+	return false;
+}
+StringName ZigScript::_get_instance_base_type() const {
+	return StringName();
+}
+void *ZigScript::_instance_create(Object *p_for_object) const {
+	return nullptr;
+}
+void *ZigScript::_placeholder_instance_create(Object *p_for_object) const {
+	return nullptr;
+}
+bool ZigScript::_instance_has(Object *p_object) const {
+	return false;
+}
+bool ZigScript::_has_source_code() const {
+	return true;
+}
+String ZigScript::_get_source_code() const {
+	return source_code;
+}
+void ZigScript::_set_source_code(const String &p_code) {
+	source_code = p_code;
+}
+Error ZigScript::_reload(bool p_keep_state) {
+	return Error::OK;
+}
+TypedArray<Dictionary> ZigScript::_get_documentation() const {
+	return TypedArray<Dictionary>();
+}
+String ZigScript::_get_class_icon_path() const {
+	return String("res://addons/godot_sandbox/ZigScript.svg");
+}
+bool ZigScript::_has_method(const StringName &p_method) const {
+	return false;
+}
+bool ZigScript::_has_static_method(const StringName &p_method) const {
+	return false;
+}
+Dictionary ZigScript::_get_method_info(const StringName &p_method) const {
+	return Dictionary();
+}
+bool ZigScript::_is_tool() const {
+	return true;
+}
+bool ZigScript::_is_valid() const {
+	return true;
+}
+bool ZigScript::_is_abstract() const {
+	return true;
+}
+ScriptLanguage *ZigScript::_get_language() const {
+	return ZigScriptLanguage::get_singleton();
+}
+bool ZigScript::_has_script_signal(const StringName &p_signal) const {
+	return false;
+}
+TypedArray<Dictionary> ZigScript::_get_script_signal_list() const {
+	return TypedArray<Dictionary>();
+}
+bool ZigScript::_has_property_default_value(const StringName &p_property) const {
+	return false;
+}
+Variant ZigScript::_get_property_default_value(const StringName &p_property) const {
+	return Variant();
+}
+void ZigScript::_update_exports() {}
+TypedArray<Dictionary> ZigScript::_get_script_method_list() const {
+	return TypedArray<Dictionary>();
+}
+TypedArray<Dictionary> ZigScript::_get_script_property_list() const {
+	return TypedArray<Dictionary>();
+}
+int32_t ZigScript::_get_member_line(const StringName &p_member) const {
+	return 0;
+}
+Dictionary ZigScript::_get_constants() const {
+	return Dictionary();
+}
+TypedArray<StringName> ZigScript::_get_members() const {
+	return TypedArray<StringName>();
+}
+bool ZigScript::_is_placeholder_fallback_enabled() const {
+	return false;
+}
+Variant ZigScript::_get_rpc_config() const {
+	return Variant();
+}
+
+ZigScript::ZigScript() {
+	source_code = R"C0D3(
+// TODO: Implement me.
+)C0D3";
+}

--- a/src/zig/script_zig.h
+++ b/src/zig/script_zig.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "../docker.h"
+#include <godot_cpp/classes/script_extension.hpp>
+#include <godot_cpp/classes/script_language.hpp>
+
+using namespace godot;
+
+class ZigScript : public ScriptExtension {
+	GDCLASS(ZigScript, ScriptExtension);
+
+protected:
+	static void _bind_methods() {}
+	String source_code;
+
+public:
+	virtual bool _editor_can_reload_from_file() override;
+	virtual void _placeholder_erased(void *p_placeholder) override;
+	virtual bool _can_instantiate() const override;
+	virtual Ref<Script> _get_base_script() const override;
+	virtual StringName _get_global_name() const override;
+	virtual bool _inherits_script(const Ref<Script> &p_script) const override;
+	virtual StringName _get_instance_base_type() const override;
+	virtual void *_instance_create(Object *p_for_object) const override;
+	virtual void *_placeholder_instance_create(Object *p_for_object) const override;
+	virtual bool _instance_has(Object *p_object) const override;
+	virtual bool _has_source_code() const override;
+	virtual String _get_source_code() const override;
+	virtual void _set_source_code(const String &p_code) override;
+	virtual Error _reload(bool p_keep_state) override;
+	virtual TypedArray<Dictionary> _get_documentation() const override;
+	virtual String _get_class_icon_path() const override;
+	virtual bool _has_method(const StringName &p_method) const override;
+	virtual bool _has_static_method(const StringName &p_method) const override;
+	virtual Dictionary _get_method_info(const StringName &p_method) const override;
+	virtual bool _is_tool() const override;
+	virtual bool _is_valid() const override;
+	virtual bool _is_abstract() const override;
+	virtual ScriptLanguage *_get_language() const override;
+	virtual bool _has_script_signal(const StringName &p_signal) const override;
+	virtual TypedArray<Dictionary> _get_script_signal_list() const override;
+	virtual bool _has_property_default_value(const StringName &p_property) const override;
+	virtual Variant _get_property_default_value(const StringName &p_property) const override;
+	virtual void _update_exports() override;
+	virtual TypedArray<Dictionary> _get_script_method_list() const override;
+	virtual TypedArray<Dictionary> _get_script_property_list() const override;
+	virtual int32_t _get_member_line(const StringName &p_member) const override;
+	virtual Dictionary _get_constants() const override;
+	virtual TypedArray<StringName> _get_members() const override;
+	virtual bool _is_placeholder_fallback_enabled() const override;
+	virtual Variant _get_rpc_config() const override;
+
+	static void DockerContainerStart() {
+		if (!docker_container_started) {
+			Array output;
+			if (Docker::ContainerStart(docker_container_name, docker_image_name, output))
+				docker_container_started = true;
+			else {
+				UtilityFunctions::print(output);
+				ERR_PRINT("Failed to start Docker container");
+			}
+		}
+	}
+	static void DockerContainerStop() {
+		if (docker_container_started) {
+			Docker::ContainerStop(docker_container_name);
+			docker_container_started = false;
+		}
+	}
+	static int DockerContainerVersion() {
+		DockerContainerStart();
+		if (docker_container_version == 0)
+			docker_container_version =
+					Docker::ContainerVersion(docker_container_name, { "/usr/api/build.sh", "--version" });
+		return docker_container_version;
+	}
+	static bool DockerContainerExecute(const PackedStringArray &p_arguments, Array &output) {
+		return Docker::ContainerExecute(docker_container_name, p_arguments, output);
+	}
+
+	ZigScript();
+	~ZigScript() {}
+
+private:
+	static inline bool docker_container_started = false;
+	static inline int docker_container_version = 0;
+	static inline const char *docker_container_name = "godot-zig-compiler";
+	static inline const char *docker_image_name = "ghcr.io/libriscv/zig_compiler";
+};


### PR DESCRIPTION
```zig
const std = @import("std");

comptime {
	asm (
		\\.global fast_exit;
		\\.type fast_exit, @function;
		\\fast_exit:
		\\  .insn i SYSTEM, 0, x0, x0, 0x7ff
		\\.pushsection .comment
		\\.string "Godot Zig API v1"
		\\.popsection
	);
}

pub fn main() !void {
	const stdout = std.io.getStdOut().writer();
	try stdout.print("Hello {d} World from Zig!\n", .{123});
}

const V = union {
	b: bool,
	i: i64,
	f: f64,
	bytes: [16]u8
};
const Variant = struct {
	type: i64,
	v: V,
};

export fn add(result: *Variant, x: i32, y: i32) void {
	result.* = Variant{
		.type = 2, // INT
		.v = V { .i = x + y },
	};
}
```
This initial program boots and runs correctly. The `add` function works when called from GDScript.
