### PR TITLE
Expose properties from shared instances in the inspector through ScriptInstance

### DIFF
--- a/src/elf/script_instance.h
+++ b/src/elf/script_instance.h
@@ -37,7 +37,6 @@ class ELFScriptInstance : public ScriptInstanceExtension {
 	bool auto_created_sandbox = false;
 
 	void update_methods() const;
-	static void convert_prop(const PropertyInfo &p_src, GDExtensionPropertyInfo &p_dst);
 
 	// Retrieve the sandbox and whether it was created automatically or not
 	std::tuple<Sandbox *, bool> get_sandbox() const;

--- a/src/elf/script_instance_helper.h
+++ b/src/elf/script_instance_helper.h
@@ -35,7 +35,7 @@ static StringName *stringname_alloc(const String &p_str) {
 
 static GDExtensionPropertyInfo create_property_type(const Dictionary &p_src) {
 	GDExtensionPropertyInfo p_dst;
-	//p_dst.type = p_src["type"];
+	p_dst.type = (GDExtensionVariantType) int(p_src["type"]);
 	p_dst.name = stringname_alloc(p_src["name"]);
 	p_dst.class_name = stringname_alloc(p_src["class_name"]);
 	p_dst.hint = p_src["hint"];

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -100,6 +100,26 @@ void Sandbox::_bind_methods() {
 	ADD_GROUP("Sandboxed Properties", "custom_");
 }
 
+std::vector<PropertyInfo> Sandbox::create_sandbox_property_list() const {
+	std::vector<PropertyInfo> list;
+	// Create a list of properties for the Sandbox class only.
+	// This is used to expose the properties to the editor.
+
+	// Group for sandbox restrictions.
+	list.push_back(PropertyInfo(Variant::INT, "references_max", PROPERTY_HINT_NONE, "Maximum objects and variants referenced by a sandbox call"));
+	list.push_back(PropertyInfo(Variant::INT, "memory_max", PROPERTY_HINT_NONE, "Maximum memory (in MiB) used by the sandboxed program"));
+	list.push_back(PropertyInfo(Variant::INT, "execution_timeout", PROPERTY_HINT_NONE, "Maximum millions of instructions executed before cancelling execution"));
+	list.push_back(PropertyInfo(Variant::BOOL, "use_unboxed_arguments", PROPERTY_HINT_NONE, "Use unboxed arguments for VM function calls"));
+
+	// Group for monitored Sandbox health.
+	list.push_back(PropertyInfo(Variant::INT, "monitor_heap_usage", PROPERTY_HINT_NONE, "Current arena usage"));
+	list.push_back(PropertyInfo(Variant::INT, "monitor_exceptions", PROPERTY_HINT_NONE, "Number of exceptions thrown"));
+	list.push_back(PropertyInfo(Variant::INT, "monitor_execution_timeouts", PROPERTY_HINT_NONE, "Number of execution timeouts"));
+	list.push_back(PropertyInfo(Variant::INT, "monitor_calls_made", PROPERTY_HINT_NONE, "Number of calls made"));
+
+	return list;
+}
+
 Sandbox::Sandbox() {
 	this->m_use_unboxed_arguments = SandboxProjectSettings::use_native_types();
 	this->m_global_instance_count += 1;

--- a/src/sandbox.h
+++ b/src/sandbox.h
@@ -260,6 +260,11 @@ public:
 	std::vector<SandboxProperty> &get_properties() { return m_properties; }
 	const std::vector<SandboxProperty> &get_properties() const { return m_properties; }
 
+	/// @brief Get the list of sandbox properties as a dictionary.
+	/// @note These are unrelated to SandboxProperty objects. It's all the properties that are exposed to the Godot editor.
+	/// @return The dictionary of sandbox properties.
+	std::vector<PropertyInfo> create_sandbox_property_list() const;
+
 	// -= Program management & public functions =-
 
 	/// @brief Check if a program has been loaded into the sandbox.
@@ -344,6 +349,12 @@ private:
 	// Restrictions
 	std::unordered_set<godot::Object *> m_allowed_objects;
 	godot::HashSet<String> m_allowed_classes;
+	// If an object is not in the allowed list, and a callable is set for the
+	// just-in-time allowed objects, it will be called to check if the object is allowed.
+	Callable m_just_in_time_allowed_objects;
+	// If a class is not in the allowed list, and a callable is set for the
+	// just-in-time allowed classes, it will be called to check if the class is allowed.
+	Callable m_just_in_time_allowed_classes;
 
 	Ref<ELFScript> m_program_data;
 


### PR DESCRIPTION
These were previously only accessible through scripting. Now they can be seen in the editor inspector.

![image](https://github.com/user-attachments/assets/ff925d76-b1ed-491e-9217-49fb834bf277)
