### PR TITLE
Allow creating public API at init through system call

### DIFF
--- a/program/rust/docker/src/godot/api.rs
+++ b/program/rust/docker/src/godot/api.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
-use std::arch::asm;
-use std::arch::global_asm;
+use core::arch::asm;
+use core::arch::global_asm;
+use core::ffi::c_void;
+use crate::godot::variant;
 
 pub struct Engine
 {
@@ -19,6 +21,65 @@ impl Engine
 		}
 		return is_editor != 0;
 	}
+}
+
+#[repr(C)]
+struct GuestFunctionExtra
+{
+	pub desc: *const u8,
+	pub desc_len: usize,
+	pub return_type: *const u8,
+	pub return_type_len: usize,
+	pub args: *const u8,
+	pub args_len: usize,
+}
+
+fn register_public_api_c_func(name: &str, address: *mut c_void, return_type: &str, args: &str) {
+	let description = "";
+	let extra = GuestFunctionExtra {
+		desc: description.as_ptr(),
+		desc_len: description.len(),
+		return_type: return_type.as_ptr(),
+		return_type_len: return_type.len(),
+		args: args.as_ptr(),
+		args_len: args.len(),
+	};
+	unsafe {
+		asm!("ecall",
+			in("a7") 547, // ECALL_SANDBOX_ADD
+			in("a0") 1, // SANDBOX_PUBLIC_API
+			in("a1") name.as_ptr(),
+			in("a2") name.len(),
+			in("a3") address,
+			in("a4") &extra,
+			options(nostack));
+	}
+}
+
+// Register a public API function with a single argument
+pub fn register_public_api_func0(name: &str, func: extern "C" fn() -> variant::Variant, return_type: &str, args: &str) {
+	register_public_api_c_func(name, func as *mut c_void, return_type, args);
+}
+pub fn register_public_api_func1<T>(name: &str, func: extern "C" fn(T) -> variant::Variant, return_type: &str, args: &str) {
+	register_public_api_c_func(name, func as *mut c_void, return_type, args);
+}
+pub fn register_public_api_func2<T, U>(name: &str, func: extern "C" fn(T, U) -> variant::Variant, return_type: &str, args: &str) {
+	register_public_api_c_func(name, func as *mut c_void, return_type, args);
+}
+pub fn register_public_api_func3<T, U, V>(name: &str, func: extern "C" fn(T, U, V) -> variant::Variant, return_type: &str, args: &str) {
+	register_public_api_c_func(name, func as *mut c_void, return_type, args);
+}
+pub fn register_public_api_func4<T, U, V, W>(name: &str, func: extern "C" fn(T, U, V, W) -> variant::Variant, return_type: &str, args: &str) {
+	register_public_api_c_func(name, func as *mut c_void, return_type, args);
+}
+pub fn register_public_api_func5<T, U, V, W, X>(name: &str, func: extern "C" fn(T, U, V, W, X) -> variant::Variant, return_type: &str, args: &str) {
+	register_public_api_c_func(name, func as *mut c_void, return_type, args);
+}
+pub fn register_public_api_func6<T, U, V, W, X, Y>(name: &str, func: extern "C" fn(T, U, V, W, X, Y) -> variant::Variant, return_type: &str, args: &str) {
+	register_public_api_c_func(name, func as *mut c_void, return_type, args);
+}
+pub fn register_public_api_func7<T, U, V, W, X, Y, Z>(name: &str, func: extern "C" fn(T, U, V, W, X, Y, Z) -> variant::Variant, return_type: &str, args: &str) {
+	register_public_api_c_func(name, func as *mut c_void, return_type, args);
 }
 
 // Godot Rust API version embedded in the binary

--- a/program/rust/docker/src/godot/mod.rs
+++ b/program/rust/docker/src/godot/mod.rs
@@ -1,4 +1,6 @@
 pub mod api;
 pub mod variant;
 pub mod node;
+pub mod string;
 pub mod sysalloc;
+pub mod syscalls;

--- a/program/rust/docker/src/godot/string.rs
+++ b/program/rust/docker/src/godot/string.rs
@@ -1,0 +1,30 @@
+use super::syscalls::*;
+
+#[repr(C)]
+pub struct GodotString {
+	pub reference: i32
+}
+
+impl GodotString {
+	pub fn new() -> GodotString {
+		GodotString {
+			reference: i32::MIN
+		}
+	}
+
+	pub fn create(s: &str) -> GodotString {
+		let mut godot_string = GodotString::new();
+		godot_string.reference = godot_string_create(s);
+		godot_string
+	}
+
+	pub fn from_ref(var_ref: i32) -> GodotString {
+		GodotString {
+			reference: var_ref
+		}
+	}
+
+	pub fn to_string(&self) -> String {
+		godot_string_to_string(self.reference)
+	}
+}

--- a/program/rust/docker/src/godot/syscalls.rs
+++ b/program/rust/docker/src/godot/syscalls.rs
@@ -1,0 +1,94 @@
+#![allow(dead_code)]
+use core::arch::asm;
+const ECALL_STRING_CREATE: u32 = 525;
+const ECALL_STRING_OPS: u32 = 526;
+const STRING_OP_TO_STD_STRING: u32 = 7;
+const STD_STRING_SSO_SIZE: usize = 16;
+
+#[repr(C)]
+pub(self) union CapacityOrSSO {
+	pub cap: usize,
+	pub sso: [u8; STD_STRING_SSO_SIZE],
+}
+
+#[repr(C)]
+pub struct GuestStdString {
+	// 64-bit pointer + 64-bit length + 64-bit capacity OR 16-byte SSO data
+	pub ptr: *const char,
+	pub len: usize,
+	pub(self) cap_or_sso: CapacityOrSSO,
+}
+
+impl GuestStdString
+{
+	pub fn new(s: &str) -> GuestStdString
+	{
+		if s.len() <= STD_STRING_SSO_SIZE {
+			let mut sso = [0; STD_STRING_SSO_SIZE];
+			for i in 0..s.len() {
+				sso[i] = s.as_bytes()[i];
+			}
+			let v = GuestStdString { ptr: s.as_ptr() as *const char, len: s.len(), cap_or_sso: CapacityOrSSO { sso: sso } };
+			return v;
+		}
+
+		let v = GuestStdString { ptr: s.as_ptr() as *const char, len: s.len(), cap_or_sso: CapacityOrSSO { cap: s.len() } };
+		v
+	}
+
+	pub fn new_empty() -> GuestStdString
+	{
+		let v = GuestStdString { ptr: std::ptr::null(), len: 0, cap_or_sso: CapacityOrSSO { cap: 0 } };
+		return v;
+	}
+
+	pub fn as_str(&self) -> &str
+	{
+		unsafe {
+			let s = std::str::from_utf8_unchecked(std::slice::from_raw_parts(self.ptr as *const u8, self.len));
+			return s;
+		}
+	}
+
+	pub fn as_string(&self) -> String
+	{
+		unsafe {
+			if self.len <= STD_STRING_SSO_SIZE {
+				// We want to copy self.ptr, self.len into a new String
+				return std::string::String::from_utf8_unchecked(self.as_str().as_bytes().to_vec());
+			}
+			let s = std::string::String::from_raw_parts(self.ptr as *mut u8, self.len, self.len);
+			return s;
+		}
+	}
+}
+
+// Create a new GodotString and return the i32 reference
+// MAKE_SYSCALL(ECALL_STRING_CREATE, unsigned, sys_string_create, const char *, size_t);
+pub fn godot_string_create(string: &str) -> i32 {
+	unsafe {
+		let mut gs_ref;
+		asm!("ecall",
+			in("a7") ECALL_STRING_CREATE,
+			in("a0") string.as_ptr(),
+			in("a1") string.len(),
+			lateout("a0") gs_ref,
+		);
+		gs_ref
+	}
+}
+
+pub fn godot_string_to_string(gs: i32) -> String {
+	let mut std_string = GuestStdString::new_empty();
+	unsafe {
+		asm!("ecall",
+			in("a7") ECALL_STRING_OPS,
+			in("a0") STRING_OP_TO_STD_STRING,
+			in("a1") gs,
+			in("a2") 0,  // utf-8
+			inout("a3") &mut std_string => _, // std::string
+			lateout("a0") _,
+		);
+	}
+	std_string.as_string()
+}

--- a/program/rust/project/.cargo/config.toml
+++ b/program/rust/project/.cargo/config.toml
@@ -3,4 +3,4 @@ target = "riscv64gc-unknown-linux-gnu"
 
 [target.riscv64gc-unknown-linux-gnu]
 linker = "riscv64-linux-gnu-gcc-12"
-rustflags = ["-C", "target-feature=+crt-static","-Zexport-executable-symbols", "-C", "link_args=-Wl,--wrap=memcpy,--wrap=memmove,--wrap=memset,--wrap=memcmp,--wrap=strlen,--wrap=strcmp,--wrap=strncmp"]
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link_args=-Wl,--wrap=memcpy,--wrap=memmove,--wrap=memset,--wrap=memcmp,--wrap=strlen,--wrap=strcmp,--wrap=strncmp"]

--- a/program/rust/project/src/main.rs
+++ b/program/rust/project/src/main.rs
@@ -1,12 +1,50 @@
 mod godot;
+use godot::api::*;
+use godot::node::*;
+use godot::string::*;
 use godot::variant::*;
 
-pub fn main() {
+const SPEED: f32 = 50.0;
+
+extern "C"
+fn _physics_process(delta: f64) -> Variant {
+	if Engine::is_editor_hint() {
+		return Variant::new_nil();
+	}
+
+	let slime = get_node();
+	let sprite = get_node_from_path("AnimatedSprite2D");
+
+	let flip_h = sprite.call("is_flipped_h", &[]);
+	let direction: f32 = (flip_h.to_bool() as i32 as f32 - 0.5) * -2.0;
+
+	let mut pos = slime.call("get_position", &[]).to_vec2();
+	pos.x += direction * SPEED * delta as f32;
+
+	slime.call("set_position", &[Variant::new_vec2(pos)]);
+
+	let ray_right = get_node_from_path("raycast_right");
+	let ray_left  = get_node_from_path("raycast_left");
+	if direction > 0.0 && ray_right.call("is_colliding", &[]).to_bool() {
+		sprite.call("set_flip_h", &[Variant::new_bool(true)]);
+	}
+	else if direction < 0.0 && ray_left.call("is_colliding", &[]).to_bool() {
+		sprite.call("set_flip_h", &[Variant::new_bool(false)]);
+	}
+
+	Variant::new_nil()
 }
 
-#[no_mangle]
-pub fn public_function() -> Variant {
-	print1(&Variant::new_string("Hello from Rust!"));
+extern "C"
+fn test(val1: i32, val2: i32, val3: GodotString) -> Variant {
+	let sum = val1 + val2 + val3.to_string().parse::<i32>().unwrap();
+	Variant::new_integer(sum.into())
+}
 
-	return Variant::new_float(3.14);
+pub fn main() {
+	let v = Variant::new_string("Hello, Rust World!");
+	println!("{}", v.to_string());
+
+	register_public_api_func1("_physics_process", _physics_process, "Variant", "f64");
+	register_public_api_func3("test", test, "int", "int a, int b, String c");
 }

--- a/src/elf/script_elf.cpp
+++ b/src/elf/script_elf.cpp
@@ -322,7 +322,10 @@ void ELFScript::set_public_api_functions(Array &&p_functions) {
 	if constexpr (VERBOSE_ELFSCRIPT) {
 		printf("ELFScript::set_public_api_functions: %s\n", path.utf8().ptr());
 	}
+	this->update_public_api_functions();
+}
 
+void ELFScript::update_public_api_functions() {
 	// Update the function names
 	function_names.clear();
 	for (int i = 0; i < functions.size(); i++) {
@@ -330,6 +333,7 @@ void ELFScript::set_public_api_functions(Array &&p_functions) {
 		function_names.push_back(func["name"]);
 	}
 
+	// Update the instance methods
 	for (ELFScriptInstance *instance : this->instances) {
 		instance->update_methods();
 	}

--- a/src/elf/script_elf.h
+++ b/src/elf/script_elf.h
@@ -34,6 +34,7 @@ public:
 	PackedStringArray function_names;
 
 	void set_public_api_functions(Array &&p_functions);
+	void update_public_api_functions();
 	String get_elf_programming_language() const;
 	int get_elf_api_version() const noexcept { return elf_api_version; }
 	int get_source_version() const noexcept { return source_version; }

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -523,6 +523,7 @@ bool Sandbox::load(const PackedByteArray *buffer, const std::vector<std::string>
 				const gaddr_t address = func.get("address", 0x0);
 				this->m_lookup.insert_or_assign(name.hash(), address);
 			}
+			this->m_program_data->update_public_api_functions();
 		}
 	}
 
@@ -957,6 +958,10 @@ String Sandbox::lookup_address(gaddr_t address) const {
 bool Sandbox::has_function(const StringName &p_function) const {
 	const gaddr_t address = cached_address_of(p_function.hash(), p_function);
 	return address != 0x0;
+}
+
+void Sandbox::add_cached_address(int64_t hash, gaddr_t address) {
+	m_lookup.insert_or_assign(hash, address);
 }
 
 //-- Scoped objects and variants --//

--- a/src/sandbox.h
+++ b/src/sandbox.h
@@ -43,6 +43,7 @@ public:
 	static constexpr unsigned MAX_REFS = 100; // Default maximum number of references
 	static constexpr unsigned EDITOR_THROTTLE = 8; // Throttle VM calls from the editor
 	static constexpr unsigned MAX_PROPERTIES = 32; // Maximum number of sandboxed properties
+	static constexpr unsigned MAX_PUBLIC_FUNCTIONS = 128; // Maximum number of public functions
 
 	struct CurrentState {
 		std::vector<Variant> variants;
@@ -129,7 +130,7 @@ public:
 	/// @return True if the sandbox is initializing, false otherwise.
 	/// @note This is used to enforce or prevent certain operations from being performed during initialization.
 	/// For example, it's only possible to add properties or public API functions to the sandbox during initialization.
-	bool is_initializing() const { return !m_is_initialization; }
+	bool is_initializing() const { return m_is_initialization; }
 
 	// -= Sandbox Properties =-
 
@@ -176,6 +177,11 @@ public:
 	/// @param p_function The name of the function to check.
 	/// @return True if the function exists, false otherwise.
 	bool has_function(const StringName &p_function) const;
+
+	/// @brief Add a hash to address mapping to the cache.
+	/// @param hash The hash of the name.
+	/// @param address The address of the function or symbol.
+	void add_cached_address(int64_t hash, gaddr_t address);
 
 	// -= Call State Management =-
 
@@ -491,6 +497,15 @@ public:
 	/// @param use_argument_names If true, use argument names with default values in the generated API. Increases the size of the generated API and the compilation time.
 	/// @return The generated API code as a string.
 	static String generate_api(String language = "cpp", String header_extra = "", bool use_argument_names = false);
+
+	/// @brief Create a MethodInfo dictionary for a public API function.
+	/// @param name The name of the function.
+	/// @param address The address of the function.
+	/// @param description The description of the function.
+	/// @param return_type The return type of the function.
+	/// @param args The arguments of the function.
+	/// @return The MethodInfo dictionary.
+	static Dictionary create_public_api_function(std::string_view name, gaddr_t address, std::string_view description, std::string_view return_type, std::string_view args);
 
 private:
 	static void generate_runtime_cpp_api(bool use_argument_names = false);

--- a/src/sandbox_syscalls.cpp
+++ b/src/sandbox_syscalls.cpp
@@ -1551,8 +1551,8 @@ APICALL(api_string_ops) {
 
 	std::optional<const Variant *> opt_str = emu.get_scoped_variant(str_idx);
 	if (!opt_str.has_value()) {
-		ERR_PRINT("Invalid String object");
-		throw std::runtime_error("Invalid String object");
+		ERR_PRINT("Invalid String object idx: " + itos(str_idx));
+		throw std::runtime_error("Invalid String object: " + std::to_string(str_idx));
 	}
 	const Variant::Type type = opt_str.value()->get_type();
 	if (type != Variant::STRING && type != Variant::STRING_NAME && type != Variant::NODE_PATH) {


### PR DESCRIPTION
This PR does a good job at letting you define the public API from `int main()`, which opens up for other languages to participate.
