### PR TITLE
For C++, check if CMake or Scons and disable version check

### DIFF
--- a/src/cpp/resource_saver_cpp.cpp
+++ b/src/cpp/resource_saver_cpp.cpp
@@ -151,13 +151,15 @@ Error ResourceFormatSaverCPP::_save(const Ref<Resource> &p_resource, const Strin
 			handle->store_string(script->_get_source_code());
 			handle->close();
 
-			// Check if the project is a CMake project
-			if (detect_and_build_cmake_project_instead()) {
-				return Error::OK;
-			}
-
-			if (detect_and_build_scons_project_instead()) {
-				return Error::OK;
+			if (CPPScript::DetectCMakeOrSConsProject()) {
+				// Check if the project is a CMake project
+				if (detect_and_build_cmake_project_instead()) {
+					return Error::OK;
+				}
+				// Check if the project is a SCons project
+				if (detect_and_build_scons_project_instead()) {
+					return Error::OK;
+				}
 			}
 
 			// Generate the C++ run-time API in the project root

--- a/src/cpp/script_cpp.cpp
+++ b/src/cpp/script_cpp.cpp
@@ -4,6 +4,39 @@
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
 
+bool CPPScript::DetectCMakeOrSConsProject() {
+	static bool detected = false;
+	static bool detected_value = false;
+	// Avoid file system checks if the project type has already been detected
+	if (detected) {
+		return detected_value;
+	}
+	// If the project root contains a CMakeLists.txt file, or a cmake/CMakeLists.txt,
+	// build the project using CMake
+	// Get the project root using res://
+	String project_root = "res://";
+	detected = true;
+
+	// Check for CMakeLists.txt in the project root
+	const bool cmake_root = FileAccess::file_exists(project_root + "CMakeLists.txt");
+	if (cmake_root) {
+		detected_value = true;
+		return true;
+	}
+	const bool cmake_dir = FileAccess::file_exists(project_root + "cmake/CMakeLists.txt");
+	if (cmake_dir) {
+		detected_value = true;
+		return true;
+	}
+	const bool scons_root = FileAccess::file_exists(project_root + "SConstruct");
+	if (scons_root) {
+		detected_value = true;
+		return true;
+	}
+	detected_value = false;
+	return false;
+}
+
 bool CPPScript::_editor_can_reload_from_file() {
 	return true;
 }

--- a/src/cpp/script_cpp.h
+++ b/src/cpp/script_cpp.h
@@ -50,6 +50,11 @@ public:
 	virtual bool _is_placeholder_fallback_enabled() const override;
 	virtual Variant _get_rpc_config() const override;
 
+	/// @brief Detects if the project is a CMake or SCons project,
+	/// in which case Docker usage is not necessary.
+	/// @return true if the project is a CMake or SCons project.
+	static bool DetectCMakeOrSConsProject();
+
 	static void DockerContainerStart() {
 		if (!docker_container_started) {
 			Array output;

--- a/src/elf/script_instance.cpp
+++ b/src/elf/script_instance.cpp
@@ -32,6 +32,12 @@ static void handle_language_warnings(Array &warnings, const Ref<ELFScript> &scri
 	}
 	const String language = script->get_elf_programming_language();
 	if (language == "C++") {
+		// Check if the project is a CMake or SCons project and avoid
+		// using the Docker container in that case. It's a big download.
+		// This detection is cached and returns fast the second time.
+		if (CPPScript::DetectCMakeOrSConsProject()) {
+			return;
+		}
 		// Compare C++ version against Docker version
 		const int docker_version = CPPScript::DockerContainerVersion();
 		if (docker_version < 0) {


### PR DESCRIPTION
This avoids Docker usage when CMake or SCons is used