### PR TITLE
Use PLATFORM_HAS_EDITOR to disable some features on editor-less platforms

### DIFF
--- a/src/elf/script_instance.cpp
+++ b/src/elf/script_instance.cpp
@@ -6,7 +6,7 @@
 #include "../sandbox_project_settings.h"
 #include "../zig/script_zig.h"
 #include "script_elf.h"
-#include "script_instance_helper.h"
+#include "script_instance_helper.h" // register_types.h
 #include <godot_cpp/core/object.hpp>
 #include <godot_cpp/templates/local_vector.hpp>
 static constexpr bool VERBOSE_LOGGING = false;
@@ -26,6 +26,7 @@ struct ScopedTreeBase {
 	}
 };
 
+#ifdef PLATFORM_HAS_EDITOR
 static void handle_language_warnings(Array &warnings, const Ref<ELFScript> &script) {
 	if (!SandboxProjectSettings::get_docker_enabled()) {
 		return;
@@ -75,6 +76,7 @@ static void handle_language_warnings(Array &warnings, const Ref<ELFScript> &scri
 		}
 	}
 }
+#endif
 
 bool ELFScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 	if constexpr (VERBOSE_LOGGING) {
@@ -138,6 +140,7 @@ retry_callp:
 		}
 	}
 
+#ifdef PLATFORM_HAS_EDITOR
 	// Handle internal methods
 	if (p_method == StringName("_get_editor_name")) {
 		r_error.error = GDEXTENSION_CALL_OK;
@@ -161,6 +164,7 @@ retry_callp:
 		r_error.error = GDEXTENSION_CALL_OK;
 		return warnings;
 	}
+#endif
 
 	// When the script instance must have a sandbox as owner,
 	// use _enter_tree to get the sandbox instance.

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -8,24 +8,26 @@
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/core/error_macros.hpp>
 
-#include "cpp/resource_loader_cpp.h"
-#include "cpp/resource_saver_cpp.h"
-#include "cpp/script_cpp.h"
-#include "cpp/script_language_cpp.h"
 #include "elf/resource_loader_elf.h"
 #include "elf/resource_saver_elf.h"
 #include "elf/script_elf.h"
 #include "elf/script_language_elf.h"
+#include "sandbox.h"
+#include "sandbox_project_settings.h"
+#ifdef PLATFORM_HAS_EDITOR
+#include "cpp/resource_loader_cpp.h"
+#include "cpp/resource_saver_cpp.h"
+#include "cpp/script_cpp.h"
+#include "cpp/script_language_cpp.h"
 #include "rust/resource_loader_rust.h"
 #include "rust/resource_saver_rust.h"
 #include "rust/script_language_rust.h"
 #include "rust/script_rust.h"
-#include "sandbox.h"
-#include "sandbox_project_settings.h"
 #include "zig/resource_loader_zig.h"
 #include "zig/resource_saver_zig.h"
 #include "zig/script_language_zig.h"
 #include "zig/script_zig.h"
+#endif
 
 using namespace godot;
 
@@ -47,6 +49,7 @@ static void initialize_riscv_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<ELFScriptLanguage>();
 	ClassDB::register_class<ResourceFormatLoaderELF>();
 	ClassDB::register_class<ResourceFormatSaverELF>();
+#ifdef PLATFORM_HAS_EDITOR
 	ClassDB::register_class<CPPScript>();
 	ClassDB::register_class<CPPScriptLanguage>();
 	ClassDB::register_class<ResourceFormatLoaderCPP>();
@@ -59,12 +62,14 @@ static void initialize_riscv_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<ZigScriptLanguage>();
 	ClassDB::register_class<ResourceFormatLoaderZig>();
 	ClassDB::register_class<ResourceFormatSaverZig>();
+#endif
 	elf_loader.instantiate();
 	elf_saver.instantiate();
 	ResourceLoader::get_singleton()->add_resource_format_loader(elf_loader, true);
 	ResourceSaver::get_singleton()->add_resource_format_saver(elf_saver);
 	elf_language = memnew(ELFScriptLanguage);
 	Engine::get_singleton()->register_script_language(elf_language);
+#ifdef PLATFORM_HAS_EDITOR
 	CPPScriptLanguage::init();
 	ResourceFormatLoaderCPP::init();
 	ResourceFormatSaverCPP::init();
@@ -74,6 +79,7 @@ static void initialize_riscv_module(ModuleInitializationLevel p_level) {
 	ZigScriptLanguage::init();
 	ResourceFormatLoaderZig::init();
 	ResourceFormatSaverZig::init();
+#endif
 	SandboxProjectSettings::register_settings();
 }
 
@@ -82,9 +88,11 @@ static void uninitialize_riscv_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 	Engine *engine = Engine::get_singleton();
+#ifdef PLATFORM_HAS_EDITOR
 	engine->unregister_script_language(CPPScriptLanguage::get_singleton());
 	engine->unregister_script_language(RustScriptLanguage::get_singleton());
 	engine->unregister_script_language(ZigScriptLanguage::get_singleton());
+#endif
 	if (elf_language) {
 		engine->unregister_script_language(elf_language);
 		memdelete(elf_language);
@@ -95,12 +103,14 @@ static void uninitialize_riscv_module(ModuleInitializationLevel p_level) {
 	ResourceSaver::get_singleton()->remove_resource_format_saver(elf_saver);
 	elf_loader.unref();
 	elf_saver.unref();
+#ifdef PLATFORM_HAS_EDITOR
 	ResourceFormatLoaderCPP::deinit();
 	ResourceFormatSaverCPP::deinit();
 	ResourceFormatLoaderRust::deinit();
 	ResourceFormatSaverRust::deinit();
 	ResourceFormatLoaderZig::deinit();
 	ResourceFormatSaverZig::deinit();
+#endif
 }
 
 extern "C" {

--- a/src/register_types.h
+++ b/src/register_types.h
@@ -2,3 +2,9 @@
 #include <godot_cpp/classes/script_language.hpp>
 
 godot::ScriptLanguage *get_elf_language();
+
+#if defined(__wasm__) || defined(__ios__) || defined(__ANDROID__)
+#define EDITORLESS_PLATFORM
+#else
+#define PLATFORM_HAS_EDITOR
+#endif


### PR DESCRIPTION
This produces smaller artifacts on some platforms. Currently WASM, iOS and Android
