### PR TITLE
Compile audited SafeGDScript syscalls as counted dyncalls

### DIFF
--- a/src/gdscript/compiler/CMakeLists.txt
+++ b/src/gdscript/compiler/CMakeLists.txt
@@ -193,6 +193,10 @@ if (BUILD_TESTING)
 	# the rest of the tests still build.
 	set(LIBRISCV_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../ext/libriscv/lib)
 	if (NOT CMAKE_CROSSCOMPILING AND EXISTS ${LIBRISCV_DIR}/CMakeLists.txt)
+		add_gdscript_test(test_syscall_codegen tests/test_syscall_codegen.cpp)
+		target_compile_definitions(test_syscall_codegen PRIVATE
+			SGD_SYSCALL_SOURCE="${CMAKE_CURRENT_SOURCE_DIR}/tests/syscall_counts.gd")
+
 		if (NOT TARGET riscv)
 			set(RISCV_32I OFF CACHE BOOL "" FORCE)
 			set(RISCV_BINARY_TRANSLATION OFF CACHE BOOL "" FORCE)

--- a/src/gdscript/compiler/riscv_codegen.cpp
+++ b/src/gdscript/compiler/riscv_codegen.cpp
@@ -1,3 +1,4 @@
+#include "syscall_abi.h"
 #include "riscv_codegen.h"
 #include <unordered_set>
 #include "compiler_exception.h"
@@ -262,8 +263,7 @@ void RISCVCodeGen::emit_folded_initializers(const IRProgram& program, bool membe
 			emit_li(REG_A1, Variant::STRING);
 			emit_li(REG_A2, 1); // method 1: { char*, size_t }
 			emit_mv(REG_A3, REG_T1);
-			emit_li(REG_A7, ECALL_VCREATE);
-			emit_ecall();
+			emit_syscall(ECALL_VCREATE);
 
 			emit_add_offset(REG_SP, REG_SP, total_space);
 		} else if (global.init_type == IRGlobalVar::InitType::EMPTY_ARRAY) {
@@ -271,15 +271,13 @@ void RISCVCodeGen::emit_folded_initializers(const IRProgram& program, bool membe
 			emit_li(REG_A1, Variant::ARRAY);
 			emit_li(REG_A2, 0);
 			emit_li(REG_A3, 0);
-			emit_li(REG_A7, ECALL_VCREATE);
-			emit_ecall();
+			emit_syscall(ECALL_VCREATE);
 		} else if (global.init_type == IRGlobalVar::InitType::EMPTY_DICT) {
 			emit_mv(REG_A0, REG_T0);
 			emit_li(REG_A1, Variant::DICTIONARY);
 			emit_li(REG_A2, 0);
 			emit_li(REG_A3, 0);
-			emit_li(REG_A7, ECALL_VCREATE);
-			emit_ecall();
+			emit_syscall(ECALL_VCREATE);
 		} else if (global.init_type == IRGlobalVar::InitType::NULL_VAL) {
 			emit_li(REG_T1, Variant::NIL);
 			emit_sw(REG_T1, REG_T0, 0);
@@ -395,8 +393,7 @@ std::vector<uint8_t> RISCVCodeGen::generate(const IRProgram& program) {
 			emit_la(REG_A5, global.getter_function);
 		}
 		emit_address_of_global(REG_A6, i);
-		emit_li(REG_A7, ECALL_SANDBOX_ADD);
-		emit_ecall();
+		emit_syscall(ECALL_SANDBOX_ADD);
 		if (!global.export_hint.is_default()) {
 			const std::string hint_label = ".LHINT" + std::to_string(i);
 			m_rodata_strings.push_back({global.export_hint.hint_string, hint_label});
@@ -408,8 +405,7 @@ std::vector<uint8_t> RISCVCodeGen::generate(const IRProgram& program) {
 			emit_la(REG_A4, hint_label);
 			emit_li(REG_A5, static_cast<int64_t>(global.export_hint.hint_string.length()));
 			emit_li(REG_A6, global.export_hint.usage);
-			emit_li(REG_A7, ECALL_SANDBOX_ADD);
-			emit_ecall();
+			emit_syscall(ECALL_SANDBOX_ADD);
 		} else if (script_variable) {
 			emit_li(REG_A0, SANDBOX_ADD_PROPERTY_HINT);
 			emit_la(REG_A1, name_label);
@@ -418,8 +414,7 @@ std::vector<uint8_t> RISCVCodeGen::generate(const IRProgram& program) {
 			emit_la(REG_A4, name_label);
 			emit_li(REG_A5, 0);
 			emit_li(REG_A6, USAGE_SCRIPT_VARIABLE);
-			emit_li(REG_A7, ECALL_SANDBOX_ADD);
-			emit_ecall();
+			emit_syscall(ECALL_SANDBOX_ADD);
 		}
 	}
 
@@ -1555,8 +1550,7 @@ void RISCVCodeGen::gen_syscall_get_obj(const IRInstruction& instr, int result_vr
 
 	emit_la(REG_A0, rodata_string(str));
 	emit_li(REG_A1, string_len);
-	emit_li(REG_A7, ECALL_GET_OBJ);
-	emit_ecall();
+	emit_syscall(ECALL_GET_OBJ);
 
 	emit_syscall_result(result_vreg, REG_A0, result_offset, 24); // OBJECT
 }
@@ -1583,8 +1577,7 @@ void RISCVCodeGen::gen_syscall_node_create(const IRInstruction& instr, int resul
 	emit_li(REG_A2, string_len);
 	emit_li(REG_A3, 0);
 	emit_li(REG_A4, 0);
-	emit_li(REG_A7, ECALL_NODE_CREATE);
-	emit_ecall();
+	emit_syscall(ECALL_NODE_CREATE);
 
 	emit_syscall_result(result_vreg, REG_A0, result_offset, 24); // OBJECT
 }
@@ -1614,8 +1607,7 @@ void RISCVCodeGen::gen_syscall_class_bind(const IRInstruction& instr, int result
 	emit_container_handle(REG_A0, dict_vreg, dict_offset);
 	emit_la(REG_A1, rodata_string(str));
 	emit_li(REG_A2, string_len);
-	emit_li(REG_A7, ECALL_CLASS_BIND);
-	emit_ecall();
+	emit_syscall(ECALL_CLASS_BIND);
 
 	emit_li(REG_T0, Variant::NIL);
 	emit_store_variant_type(REG_T0, REG_SP, result_offset);
@@ -1635,8 +1627,7 @@ void RISCVCodeGen::gen_syscall_array_size(const IRInstruction& instr, int result
 	spill_around_syscall({REG_A0});
 
 	emit_container_handle(REG_A0, array_vreg, array_offset);
-	emit_li(REG_A7, ECALL_ARRAY_SIZE);
-	emit_ecall();
+	emit_syscall(ECALL_ARRAY_SIZE);
 
 	emit_syscall_result(result_vreg, REG_A0, result_offset, 2); // INT
 }
@@ -1656,8 +1647,7 @@ void RISCVCodeGen::gen_syscall_string_size(const IRInstruction& instr, int resul
 	spill_around_syscall({REG_A0});
 
 	emit_container_handle(REG_A0, string_vreg, string_offset);
-	emit_li(REG_A7, ECALL_STRING_SIZE);
-	emit_ecall();
+	emit_syscall(ECALL_STRING_SIZE);
 
 	emit_syscall_result(result_vreg, REG_A0, result_offset, 2); // INT
 }
@@ -1679,8 +1669,7 @@ void RISCVCodeGen::gen_syscall_array_at(const IRInstruction& instr, int result_v
 	emit_container_handle(REG_A0, array_vreg, array_offset);
 	emit_ld(REG_A1, REG_SP, index_offset + 8); // int64, not int32
 	emit_load_stack_offset(REG_A2, result_offset);
-	emit_li(REG_A7, ECALL_ARRAY_AT);
-	emit_ecall();
+	emit_syscall(ECALL_ARRAY_AT);
 }
 
 void RISCVCodeGen::gen_syscall_string_at(const IRInstruction& instr, int result_vreg) {
@@ -1699,8 +1688,7 @@ void RISCVCodeGen::gen_syscall_string_at(const IRInstruction& instr, int result_
 
 	emit_container_handle(REG_A0, string_vreg, string_offset);
 	emit_ld(REG_A1, REG_SP, index_offset + 8); // int64, not int32
-	emit_li(REG_A7, ECALL_STRING_AT);
-	emit_ecall();
+	emit_syscall(ECALL_STRING_AT);
 
 	emit_syscall_result(result_vreg, REG_A0, result_offset, Variant::STRING);
 }
@@ -1725,8 +1713,7 @@ void RISCVCodeGen::gen_syscall_variant_get(const IRInstruction& instr, int resul
 	emit_load_stack_offset(REG_A0, subject_offset);
 	emit_load_stack_offset(REG_A1, key_offset);
 	emit_load_stack_offset(REG_A2, result_offset);
-	emit_li(REG_A7, ECALL_VARIANT_GET);
-	emit_ecall();
+	emit_syscall(ECALL_VARIANT_GET);
 }
 
 // a0 = string, a1 = first character, a2 = how many at most (an immediate: the
@@ -1750,8 +1737,7 @@ void RISCVCodeGen::gen_syscall_string_batch(const IRInstruction& instr, int resu
 	emit_container_handle(REG_A0, string_vreg, string_offset);
 	emit_ld(REG_A1, REG_SP, index_offset + 8); // int64, not int32
 	emit_li(REG_A2, max_count);
-	emit_li(REG_A7, ECALL_STRING_BATCH);
-	emit_ecall();
+	emit_syscall(ECALL_STRING_BATCH);
 
 	emit_syscall_result(result_vreg, REG_A0, result_offset, Variant::INT);
 }
@@ -1784,8 +1770,7 @@ void RISCVCodeGen::gen_syscall_string_codepoint_batch(const IRInstruction& instr
 	emit_ld(REG_A1, REG_SP, get_variant_stack_offset(index_vreg) + VARIANT_DATA_OFFSET);
 	emit_li(REG_A2, max_count);
 	emit_add_offset(REG_A3, REG_SP, buffer->second);
-	emit_li(REG_A7, ECALL_STRING_CODEPOINT_BATCH);
-	emit_ecall();
+	emit_syscall(ECALL_STRING_CODEPOINT_BATCH);
 	emit_syscall_result(result_vreg, REG_A0, result_offset, Variant::INT);
 }
 
@@ -1810,8 +1795,7 @@ void RISCVCodeGen::gen_syscall_array_batch(const IRInstruction& instr, int resul
 	emit_ld(REG_A1, REG_SP, get_variant_stack_offset(index_vreg) + VARIANT_DATA_OFFSET);
 	emit_li(REG_A2, max_count);
 	emit_add_offset(REG_A3, REG_SP, buffer->second);
-	emit_li(REG_A7, ECALL_ARRAY_BATCH);
-	emit_ecall();
+	emit_syscall(ECALL_ARRAY_BATCH);
 	emit_syscall_result(result_vreg, REG_A0, result_offset, Variant::INT);
 }
 
@@ -1871,8 +1855,7 @@ void RISCVCodeGen::gen_syscall_dictionary_ops(const IRInstruction& instr, int re
 		emit_load_stack_offset(REG_A4, default_offset);
 	}
 
-	emit_li(REG_A7, ECALL_DICTIONARY_OPS);
-	emit_ecall();
+	emit_syscall(ECALL_DICTIONARY_OPS, emitted_op);
 
 	if (returns_in_register) {
 		emit_syscall_result(result_vreg, REG_A0,
@@ -1910,8 +1893,7 @@ void RISCVCodeGen::gen_dict_const(const IRInstruction& instr) {
 	if (is_get || is_set) {
 		emit_add_offset(REG_A4, REG_SP, value_offset);
 	}
-	emit_li(REG_A7, ECALL_DICTIONARY_OPS);
-	emit_ecall();
+	emit_syscall(ECALL_DICTIONARY_OPS);
 
 	if (!is_set && !is_get) {
 		emit_syscall_result(instr.operands[0].reg_index(), REG_A0, value_offset, Variant::BOOL);
@@ -1944,8 +1926,7 @@ void RISCVCodeGen::gen_struct_check(const IRInstruction& instr) {
 	emit_container_handle(REG_A1, dict_vreg, dict_offset + table_space);
 	emit_mv(REG_A2, REG_SP);
 	emit_li(REG_A3, count);
-	emit_li(REG_A7, ECALL_DICTIONARY_OPS);
-	emit_ecall();
+	emit_syscall(ECALL_DICTIONARY_OPS);
 	emit_syscall_result(result_vreg, REG_A0, result_offset + table_space, Variant::BOOL);
 	emit_stack_adjust(table_space);
 }
@@ -1982,8 +1963,7 @@ void RISCVCodeGen::gen_make_dictionary_keyed(const IRInstruction& instr) {
 	emit_mv(REG_A2, REG_SP);
 	emit_li(REG_A3, count);
 	emit_add_offset(REG_A4, REG_SP, key_space);
-	emit_li(REG_A7, ECALL_DICTIONARY_OPS);
-	emit_ecall();
+	emit_syscall(ECALL_DICTIONARY_OPS);
 	emit_stack_adjust(total_space);
 }
 
@@ -2004,8 +1984,7 @@ void RISCVCodeGen::gen_get_node(const IRInstruction& instr) {
 	emit_li(REG_A0, 0);
 	emit_la(REG_A1, rodata_string(path));
 	emit_li(REG_A2, static_cast<int>(path.size()));
-	emit_li(REG_A7, ECALL_GET_NODE);
-	emit_ecall();
+	emit_syscall(ECALL_GET_NODE);
 
 	emit_syscall_result(result_vreg, REG_A0, result_offset, Variant::OBJECT);
 }
@@ -2025,8 +2004,7 @@ void RISCVCodeGen::gen_load_resource(const IRInstruction& instr) {
 	emit_la(REG_A0, rodata_string(path));
 	emit_li(REG_A1, static_cast<int>(path.size()));
 	emit_load_stack_offset(REG_A2, result_offset);
-	emit_li(REG_A7, ECALL_LOAD);
-	emit_ecall();
+	emit_syscall(ECALL_LOAD);
 }
 
 // A0=address, A1=bound Variant, A3=flags. Result is a scoped variant index.
@@ -2052,8 +2030,7 @@ void RISCVCodeGen::gen_make_callable(const IRInstruction& instr) {
 	emit_load_stack_offset(REG_A1, bound_offset);
 	emit_li(REG_A2, 0);
 	emit_li(REG_A3, ECALL_CALLABLE_VARIANT_ARGS);
-	emit_li(REG_A7, ECALL_CALLABLE_CREATE);
-	emit_ecall();
+	emit_syscall(ECALL_CALLABLE_CREATE);
 
 	emit_syscall_result(result_vreg, REG_A0, result_offset, Variant::CALLABLE);
 }
@@ -2075,8 +2052,7 @@ void RISCVCodeGen::gen_load_resource_var(const IRInstruction& instr) {
 	emit_load_stack_offset(REG_A0, path_offset);
 	emit_li(REG_A1, -1);
 	emit_load_stack_offset(REG_A2, result_offset);
-	emit_li(REG_A7, ECALL_LOAD);
-	emit_ecall();
+	emit_syscall(ECALL_LOAD);
 }
 
 void RISCVCodeGen::gen_call_syscall(const IRInstruction& instr) {
@@ -2164,8 +2140,7 @@ void RISCVCodeGen::gen_trait_test(const IRInstruction& instr) {
 	emit_li(REG_A2, int64_t(iface.name.size()));
 	emit_la(REG_A3, methods_label);
 	emit_li(REG_A4, int64_t(methods.size()));
-	emit_li(REG_A7, ECALL_OBJ_USES_TRAIT);
-	emit_ecall();
+	emit_syscall(ECALL_OBJ_USES_TRAIT);
 	emit_mv(REG_T4, REG_A0);
 	emit_sd(REG_T0, REG_T2, 0);
 	emit_sd(REG_T4, REG_T2, 8);
@@ -2211,8 +2186,7 @@ void RISCVCodeGen::gen_construct(const IRInstruction& instr) {
 	emit_load_stack_offset(REG_A0, result_offset + additional_space);
 	emit_li(REG_A1, variant_type);
 	emit_li(REG_A3, arg_count);
-	emit_li(REG_A7, ECALL_VCONSTRUCT);
-	emit_ecall();
+	emit_syscall(ECALL_VCONSTRUCT);
 
 	emit_stack_adjust(additional_space);
 }
@@ -2277,8 +2251,7 @@ void RISCVCodeGen::gen_vcall(const IRInstruction& instr) {
 	// a5 = pointer to result Variant, past the argument array
 	emit_load_stack_offset(REG_A5, result_offset + additional_space);
 
-	emit_li(REG_A7, instr.super_call ? ECALL_VCALL_SUPER : ECALL_VCALL);
-	emit_ecall();
+	emit_syscall(instr.super_call ? ECALL_VCALL_SUPER : ECALL_VCALL);
 
 	// Restore stack pointer
 	emit_stack_adjust(additional_space);
@@ -2349,8 +2322,7 @@ void RISCVCodeGen::gen_make_dictionary(const IRInstruction& instr) {
 		emit_mv(REG_A3, REG_SP);
 
 		// a7 = ECALL_VCREATE (517)
-		emit_li(REG_A7, ECALL_VCREATE);
-		emit_ecall();
+		emit_syscall(ECALL_VCREATE);
 
 		// Restore stack pointer
 		emit_add_offset(REG_SP, REG_SP, args_space);
@@ -2410,8 +2382,7 @@ void RISCVCodeGen::gen_make_array(const IRInstruction& instr) {
 		}
 
 		// a7 = ECALL_VCREATE (517)
-		emit_li(REG_A7, ECALL_VCREATE);
-		emit_ecall();
+		emit_syscall(ECALL_VCREATE);
 
 		// Restore stack pointer
 		emit_stack_adjust(args_space);
@@ -2437,8 +2408,7 @@ void RISCVCodeGen::gen_store_global(const IRInstruction& instr) {
 		spill_around_syscall({ REG_A0, REG_A1, REG_A7 });
 		emit_address_of_global(REG_A0, static_cast<size_t>(global_idx));
 		emit_load_stack_offset(REG_A1, src_offset);
-		emit_li(REG_A7, ECALL_VSTORE_GLOBAL);
-		emit_ecall();
+		emit_syscall(ECALL_VSTORE_GLOBAL);
 		return;
 	}
 
@@ -2473,8 +2443,7 @@ void RISCVCodeGen::gen_store_global(const IRInstruction& instr) {
 		emit_sw(REG_T2, REG_T0, 0);
 
 		// Call VASSIGN (syscall 503)
-		emit_li(REG_A7, ECALL_VASSIGN);
-		emit_ecall();
+		emit_syscall(ECALL_VASSIGN);
 
 		// VASSIGN returns the new index in A0
 		emit_sd(REG_A0, REG_T0, 8);
@@ -2489,8 +2458,7 @@ void RISCVCodeGen::gen_store_global(const IRInstruction& instr) {
 	if (global.holds_object) {
 		spill_around_syscall({ REG_A0, REG_A7 });
 		emit_address_of_global(REG_A0, static_cast<size_t>(global_idx));
-		emit_li(REG_A7, ECALL_OBJ_RETAIN);
-		emit_ecall();
+		emit_syscall(ECALL_OBJ_RETAIN);
 	}
 }
 
@@ -2519,8 +2487,7 @@ void RISCVCodeGen::gen_vget(const IRInstruction& instr) {
 	emit_la(REG_A1, rodata_string(str));
 	emit_li(REG_A2, string_len);
 	emit_load_stack_offset(REG_A3, result_offset);
-	emit_li(REG_A7, ECALL_OBJ_PROP_GET);
-	emit_ecall();
+	emit_syscall(ECALL_OBJ_PROP_GET);
 }
 
 void RISCVCodeGen::gen_vget_inline(const IRInstruction& instr) {
@@ -2711,8 +2678,7 @@ void RISCVCodeGen::gen_await(const IRInstruction& instr) {
 	emit_li(REG_A3, int64_t(m_fn.await_states.size()) - 1);
 	emit_la(REG_A4, m_fn.resume_label);
 	emit_li(REG_A5, result_offset - m_fn.saved_reg_space);
-	emit_li(REG_A7, ECALL_AWAIT);
-	emit_ecall();
+	emit_syscall(ECALL_AWAIT);
 
 	// a0 == 0: not awaitable, result slot already written. Fall through.
 	mark_label_use(state_label, m_code.size());
@@ -2762,8 +2728,7 @@ void RISCVCodeGen::emit_coroutine_resume_entry(const IRFunction& func) {
 	// ECALL_AWAIT_RESTORE: host copies frame back, length-checked against suspension.
 	emit_add_offset(REG_A0, REG_SP, m_fn.saved_reg_space);
 	emit_li(REG_A1, m_fn.variant_space);
-	emit_li(REG_A7, ECALL_AWAIT_RESTORE);
-	emit_ecall();
+	emit_syscall(ECALL_AWAIT_RESTORE);
 	for (size_t vreg = 0; vreg < m_fn.fixed_scalar_types.size(); vreg++) {
 		if (m_fn.scalar_aliases[vreg] == int(vreg)) reload_resident_value(int(vreg));
 	}
@@ -2807,8 +2772,7 @@ void RISCVCodeGen::gen_throw(const IRInstruction& instr) {
 		emit_mv(REG_A4, REG_ZERO);  // variant = none
 	}
 	emit_mv(REG_A5, REG_ZERO);  // function = none
-	emit_li(REG_A7, ECALL_THROW);
-	emit_ecall();
+	emit_syscall(ECALL_THROW);
 }
 
 void RISCVCodeGen::gen_print(const IRInstruction& instr) {
@@ -2852,8 +2816,7 @@ void RISCVCodeGen::gen_print(const IRInstruction& instr) {
 		if (!plain) {
 			emit_li(REG_A2, channel);
 		}
-		emit_li(REG_A7, syscall);
-		emit_ecall();
+		emit_syscall(syscall);
 
 		emit_add_offset(REG_SP, REG_SP, args_space);
 
@@ -2865,8 +2828,7 @@ void RISCVCodeGen::gen_print(const IRInstruction& instr) {
 	if (!plain) {
 		emit_li(REG_A2, channel);
 	}
-	emit_li(REG_A7, syscall);
-	emit_ecall();
+	emit_syscall(syscall);
 
 	// print() returns nil
 	emit_li(REG_T0, Variant::NIL);
@@ -3127,8 +3089,7 @@ void RISCVCodeGen::gen_make_packed_array(const IRInstruction& instr) {
 		emit_li(REG_A1, variant_type);
 		emit_li(REG_A2, 0);
 		emit_li(REG_A3, 0);
-		emit_li(REG_A7, ECALL_VCREATE);
-		emit_ecall();
+		emit_syscall(ECALL_VCREATE);
 	} else {
 		// ECALL_PACKED_ARRAY_OPS converts a contiguous Variant array to packed
 		int args_space = element_count * variant_size();
@@ -3147,8 +3108,7 @@ void RISCVCodeGen::gen_make_packed_array(const IRInstruction& instr) {
 		emit_add_offset(REG_A1, REG_SP, adjusted_dst_offset);
 		emit_mv(REG_A2, REG_SP);
 		emit_li(REG_A3, element_count);
-		emit_li(REG_A7, ECALL_PACKED_ARRAY_OPS);
-		emit_ecall();
+		emit_syscall(ECALL_PACKED_ARRAY_OPS);
 
 		emit_add_offset(REG_SP, REG_SP, args_space);
 	}
@@ -3406,8 +3366,7 @@ void RISCVCodeGen::gen_vset(const IRInstruction& instr) {
 	emit_la(REG_A1, rodata_string(str));
 	emit_li(REG_A2, string_len);
 	emit_load_stack_offset(REG_A3, value_offset);
-	emit_li(REG_A7, ECALL_OBJ_PROP_SET);
-	emit_ecall();
+	emit_syscall(ECALL_OBJ_PROP_SET);
 }
 
 void RISCVCodeGen::gen_variant_set(const IRInstruction& instr) {
@@ -3429,8 +3388,7 @@ void RISCVCodeGen::gen_variant_set(const IRInstruction& instr) {
 	emit_load_stack_offset(REG_A0, subject_offset);
 	emit_load_stack_offset(REG_A1, key_offset);
 	emit_load_stack_offset(REG_A2, value_offset);
-	emit_li(REG_A7, ECALL_VARIANT_SET);
-	emit_ecall();
+	emit_syscall(ECALL_VARIANT_SET);
 }
 
 void RISCVCodeGen::gen_call(const IRInstruction& instr) {
@@ -3535,8 +3493,7 @@ void RISCVCodeGen::gen_call_hosted(const IRInstruction& instr) {
 	emit_la(REG_A0, func_name);
 	emit_li(REG_A2, arg_count);
 	emit_load_stack_offset(REG_A3, result_offset + additional_space);
-	emit_li(REG_A7, ECALL_CALL_GUEST);
-	emit_ecall();
+	emit_syscall(ECALL_CALL_GUEST);
 
 	emit_stack_adjust(additional_space);
 }
@@ -4122,8 +4079,7 @@ void RISCVCodeGen::gen_instruction(const IRInstruction& instr) {
 			emit_container_handle(REG_A1, instr.operands[1].reg_index(), array_offset);
 			emit_li(REG_A2, 0);
 			emit_add_offset(REG_A3, REG_SP, value_offset);
-			emit_li(REG_A7, ECALL_ARRAY_OPS);
-			emit_ecall();
+			emit_syscall(ECALL_ARRAY_OPS);
 
 			// append() returns nil
 			emit_li(REG_T0, Variant::NIL);
@@ -4149,8 +4105,7 @@ void RISCVCodeGen::gen_instruction(const IRInstruction& instr) {
 				emit_add_offset(REG_A2, REG_SP, key_offset);
 			}
 			emit_add_offset(REG_A3, REG_SP, value_offset);
-			emit_li(REG_A7, ECALL_DICTIONARY_OPS);
-			emit_ecall();
+			emit_syscall(ECALL_DICTIONARY_OPS);
 			break;
 		}
 
@@ -5718,7 +5673,24 @@ void RISCVCodeGen::emit_jalr(uint8_t rd, uint8_t rs1, int32_t offset) {
 	emit_i_type(0x67, rd, 0, rs1, offset);
 }
 
+void RISCVCodeGen::emit_syscall(unsigned number, int64_t operation) {
+	const auto abi = syscall_abi(number, operation);
+	if (!abi.counted) {
+		emit_li(REG_A7, number);
+		emit_ecall();
+		return;
+	}
+	prepare_syscall();
+	// The handler index is immediate; a7 remains an ordinary argument.
+	emit_i_type(0x5b, 16 | abi.inputs, 7, 24 | (abi.floats ? 4 : 0) | abi.outputs, number);
+}
+
 void RISCVCodeGen::emit_ecall() {
+	prepare_syscall();
+	emit_i_type(0x73, 0, 0, 0, 0);
+}
+
+void RISCVCodeGen::prepare_syscall() {
 	clear_block_value_state();
 	// Breakpoint saves/restores a0 itself; all others need the prologue spill.
 	if (m_fn.in_function && !m_fn.spills_return_pointer && !m_emitting_breakpoint) {
@@ -5731,7 +5703,6 @@ void RISCVCodeGen::emit_ecall() {
 			"System call emitted by an instruction that instruction_may_ecall() "
 			"reported as frame-local");
 	}
-	emit_i_type(0x73, 0, 0, 0, 0);
 }
 
 void RISCVCodeGen::emit_ret() {
@@ -6050,8 +6021,7 @@ void RISCVCodeGen::emit_variant_create_string(int stack_offset, int string_idx, 
 	emit_li(REG_A1, variant_type);
 	emit_li(REG_A2, 1);
 	emit_mv(REG_A3, REG_SP);
-	emit_li(REG_A7, ECALL_VCREATE);
-	emit_ecall();
+	emit_syscall(ECALL_VCREATE);
 
 	emit_add_offset(REG_SP, REG_SP, total_space);
 }
@@ -6064,8 +6034,7 @@ void RISCVCodeGen::emit_vcreate_syscall(int variant_type, int method, uint8_t da
 	if (data_ptr_reg != REG_A3) {
 		emit_mv(REG_A3, data_ptr_reg);
 	}
-	emit_li(REG_A7, ECALL_VCREATE);
-	emit_ecall();
+	emit_syscall(ECALL_VCREATE);
 }
 
 void RISCVCodeGen::emit_variant_create_empty_array(int stack_offset) {
@@ -6111,8 +6080,7 @@ void RISCVCodeGen::emit_variant_eval_unary(int result_offset, uint8_t operand_ba
 	emit_li(REG_A0, op);
 	emit_add_offset(REG_A2, REG_SP, nil_offset);
 	emit_add_offset(REG_A3, REG_SP, result_offset);
-	emit_li(REG_A7, ECALL_VEVAL);
-	emit_ecall();
+	emit_syscall(ECALL_VEVAL);
 }
 
 void RISCVCodeGen::emit_variant_eval(int result_offset, int lhs_offset, int rhs_offset, int op,
@@ -6125,8 +6093,7 @@ void RISCVCodeGen::emit_variant_eval(int result_offset, int lhs_offset, int rhs_
 	emit_add_offset(REG_A1, REG_SP, lhs_offset);
 	emit_add_offset(REG_A2, REG_SP, rhs_offset);
 	emit_add_offset(REG_A3, REG_SP, result_offset);
-	emit_li(REG_A7, ECALL_VEVAL);
-	emit_ecall();
+	emit_syscall(ECALL_VEVAL);
 }
 
 bool RISCVCodeGen::has_int_fast_path(IROpcode op) {
@@ -6491,8 +6458,7 @@ void RISCVCodeGen::emit_array_element_access(bool is_set, int array_offset, int 
 		const std::string in_range = gen_local_label(".array_index");
 		mark_label_use(in_range, m_code.size());
 		emit_bge(REG_A1, REG_ZERO, 0);
-		emit_li(REG_A7, ECALL_ARRAY_SIZE);
-		emit_ecall();
+		emit_syscall(ECALL_ARRAY_SIZE);
 		emit_add(REG_A1, REG_A1, REG_A0);
 		emit_container_handle(REG_A0, array_vreg, array_offset);
 		mark_label_use(in_range, m_code.size());
@@ -6511,8 +6477,7 @@ void RISCVCodeGen::emit_array_element_access(bool is_set, int array_offset, int 
 		// without changing the syscall number or the legacy write convention.
 		emit_ori(REG_A2, REG_A2, 1);
 	}
-	emit_li(REG_A7, ECALL_ARRAY_AT);
-	emit_ecall();
+	emit_syscall(ECALL_ARRAY_AT);
 }
 
 // Frame slot or global data area, depending on whether the copy was elided.
@@ -7935,8 +7900,7 @@ void RISCVCodeGen::gen_scope_mark(const IRInstruction& instr) {
 
 	spill_around_syscall({ REG_A0, REG_A7 });
 	emit_li(REG_A0, int64_t(Scope_Op::MARK));
-	emit_li(REG_A7, ECALL_VSCOPE);
-	emit_ecall();
+	emit_syscall(ECALL_VSCOPE, int64_t(Scope_Op::MARK));
 	emit_sd(REG_A0, REG_SP, offset);
 }
 
@@ -8003,8 +7967,7 @@ void RISCVCodeGen::gen_scope_release(const IRInstruction& instr) {
 	}
 	emit_li(REG_A6, int64_t(m_instance_count) * variant_size());
 	emit_li(REG_A0, int64_t(Scope_Op::RELEASE));
-	emit_li(REG_A7, ECALL_VSCOPE);
-	emit_ecall();
+	emit_syscall(ECALL_VSCOPE);
 	if (dirty >= 0) emit_mv(uint8_t(dirty), REG_ZERO);
 	if (cached != m_fn.numeric_loop_releases.end() || dirty >= 0) define_label(skip);
 }

--- a/src/gdscript/compiler/riscv_codegen.h
+++ b/src/gdscript/compiler/riscv_codegen.h
@@ -275,6 +275,8 @@ private:
 	void emit_bgeu(uint8_t rs1, uint8_t rs2, int32_t offset);
 	void emit_jal(uint8_t rd, int32_t offset);
 	void emit_jalr(uint8_t rd, uint8_t rs1, int32_t offset);
+	void emit_syscall(unsigned number, int64_t operation = -1);
+	void prepare_syscall();
 	void emit_ecall();
 	void emit_ret();
 

--- a/src/gdscript/compiler/riscv_debug.cpp
+++ b/src/gdscript/compiler/riscv_debug.cpp
@@ -85,8 +85,7 @@ void RISCVCodeGen::emit_breakpoint(int32_t line, bool installed, bool user_stop,
 	emit_li(REG_A0, line);
 	emit_li(REG_A1, user_stop ? 1 : 0);
 	emit_li(REG_A2, source_stop ? 1 : 0);
-	emit_li(REG_A7, ECALL_BREAKPOINT);
-	emit_ecall();
+	emit_syscall(ECALL_BREAKPOINT);
 
 	emit_ld(REG_A0, REG_SP, 0);
 	emit_ld(REG_A1, REG_SP, 8);

--- a/src/gdscript/compiler/riscv_globals.cpp
+++ b/src/gdscript/compiler/riscv_globals.cpp
@@ -483,8 +483,7 @@ void RISCVCodeGen::emit_global_syscall_form(const GlobalFunction& info, const st
 	}
 
 	emit_li(REG_A0, info.utility_op);
-	emit_li(REG_A7, ECALL_UTILITY);
-	emit_ecall();
+	emit_syscall(ECALL_UTILITY, info.utility_op);
 
 	emit_global_double_result(result_offset, REG_ABI_FA0, info.result);
 }
@@ -504,8 +503,7 @@ void RISCVCodeGen::emit_global_int_syscall_form(const GlobalFunction& info, cons
 	}
 
 	emit_li(REG_A0, info.utility_op);
-	emit_li(REG_A7, ECALL_UTILITY);
-	emit_ecall();
+	emit_syscall(ECALL_UTILITY, info.utility_op);
 
 	emit_global_int_result(result_offset, REG_A0, info.result);
 }
@@ -529,8 +527,7 @@ void RISCVCodeGen::emit_global_host_form(const GlobalFunction& info, const std::
 	emit_add_offset(REG_A1, REG_SP, result_offset + args_space); // where to write the answer
 	emit_mv(REG_A2, REG_SP);                                     // the arguments
 	emit_li(REG_A3, arg_count);
-	emit_li(REG_A7, ECALL_UTILITY);
-	emit_ecall();
+	emit_syscall(ECALL_UTILITY, info.utility_op);
 
 	emit_add_offset(REG_SP, REG_SP, args_space);
 }

--- a/src/gdscript/compiler/syscall_abi.h
+++ b/src/gdscript/compiler/syscall_abi.h
@@ -11,10 +11,11 @@ struct SyscallABI {
 	uint8_t inputs;
 	uint8_t outputs;
 	bool counted;
+	bool floats = false;
 };
 
-// libriscv synchronizes fa0-fa7 inputs and fa0-fa1 outputs implicitly, for
-// both counted and legacy calls. Only integer counts are encoded. Handlers
+// FP calls synchronize fa0-fa7 inputs and fa0-fa1 outputs. Integer-only
+// counted calls clear bit 17 to skip guest FP register synchronization. Handlers
 // that inspect other CPU state or re-enter the VM still need the ordinary
 // system-call boundary. Dyncalls now synchronize instruction penalties when
 // the translation enables its instruction limit.
@@ -116,7 +117,7 @@ constexpr SyscallABI syscall_abi(unsigned number, int64_t operation = -1) {
 		case int(Utility_Op::RANDF):
 		case int(Utility_Op::RANDF_RANGE):
 		case int(Utility_Op::RANDFN):
-			return {1, 0, true}; // op in a0, doubles in fa0-fa7 -> fa0
+			return {1, 0, true, true}; // op in a0, doubles in fa0-fa7 -> fa0
 		default: return {4, 1, false}; // boxed operations can re-enter through Objects
 		}
 	case ECALL_BREAKPOINT: return {3, 0, false};
@@ -128,13 +129,18 @@ constexpr SyscallABI syscall_abi(unsigned number, int64_t operation = -1) {
 
 // Mirrors riscv::Dyncall without coupling the sandboxed compiler to the
 // host runtime headers. The codegen test checks this against the vendored ABI.
-constexpr uint32_t encode_counted_syscall(unsigned number, unsigned inputs, unsigned outputs) {
-	return (number << 20) | ((28u | outputs) << 15) | (7u << 12) |
+constexpr uint32_t encode_counted_syscall(unsigned number, unsigned inputs, unsigned outputs,
+		bool floats = true) {
+	return (number << 20) | ((24u | (floats ? 4u : 0u) | outputs) << 15) | (7u << 12) |
 		((16u | inputs) << 7) | 0x5b;
 }
 
 constexpr bool valid_counted_syscall(uint32_t word, int64_t operation = -1) {
 	const auto abi = syscall_abi(word >> 20, operation);
+	// Older counted ELFs synchronize FP even for integer-only handlers. Keep
+	// accepting them, but never let a floating-point handler opt out.
+	if (abi.floats && !(word & (1u << 17))) return false;
+	word |= 1u << 17;
 	return abi.counted && (word == encode_counted_syscall(word >> 20, abi.inputs, abi.outputs) ||
 		((word >> 20) == ECALL_DICTIONARY_OPS && word == encode_counted_syscall(ECALL_DICTIONARY_OPS, 5, 1)));
 }

--- a/src/gdscript/compiler/tests/dyncall_shim.h
+++ b/src/gdscript/compiler/tests/dyncall_shim.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "syscall_abi.h"
+#include <libriscv/machine.hpp>
+#include <libriscv/rv32i_instr.hpp>
+
+// Bare-machine compiler tests install their own syscall handlers. Give them
+// the same counted-instruction dispatch as the Sandbox before loading ELFs.
+inline void sgd_install_test_dyncalls() {
+	using namespace riscv;
+	static const Instruction<RISCV64> instruction{
+		[](CPU<RISCV64>& cpu, rv32i_instruction word) {
+			if (!gdscript::valid_counted_syscall(word.whole, int64_t(cpu.reg(REG_ARG0))))
+				cpu.trigger_exception(UNIMPLEMENTED_INSTRUCTION, word.whole);
+			Machine<RISCV64>::syscall_handlers[word.whole >> 20](cpu.machine());
+		},
+		[](char* buffer, size_t size, const CPU<RISCV64>&, rv32i_instruction word) {
+			return snprintf(buffer, size, "DYNCALL %u", word.whole >> 20);
+		}
+	};
+	CPU<RISCV64>::on_unimplemented_instruction = [](rv32i_instruction word) -> const Instruction<RISCV64>& {
+		if (gdscript::valid_counted_syscall_encoding(word.whole) &&
+			(word.whole >> 20) < Machine<RISCV64>::syscall_handlers.size()) return instruction;
+		return CPU<RISCV64>::get_unimplemented_instruction();
+	};
+}

--- a/src/gdscript/compiler/tests/syscall_counts.gd
+++ b/src/gdscript/compiler/tests/syscall_counts.gd
@@ -1,0 +1,98 @@
+func array_calls(values: Array, count: int) -> int:
+	var answer := 0
+	for i in count:
+		answer += values.size()
+	return answer
+
+func string_calls(value: String, count: int) -> int:
+	var answer := 0
+	for i in count:
+		answer += value.length()
+	return answer
+
+func dictionary_calls(value: Dictionary, count: int) -> int:
+	var answer := 0
+	for i in count:
+		answer += value.size()
+	return answer
+
+func first(value: String) -> String:
+	return value[0]
+
+func array_walk(values: Array) -> int:
+	var answer := 0
+	for value in values:
+		answer += int(value)
+	return answer
+
+func array_index_calls(values: Array, count: int) -> int:
+	var answer := 0
+	for i in count:
+		answer += int(values[0])
+	return answer
+
+func string_walk(value: String) -> int:
+	var answer := 0
+	for character in value:
+		answer += character.length()
+	return answer
+
+func string_characters(value: String) -> String:
+	var answer := ""
+	for character in value:
+		answer += character
+	return answer
+
+func codepoints(value: String) -> int:
+	var answer := 0
+	for character in value:
+		answer += ord(character)
+	return answer
+
+func power_two(value: int) -> int:
+	return nearest_po2(value)
+
+func random_integer() -> int:
+	return randi()
+
+func random_range() -> int:
+	return randi_range(7, 7)
+
+func floating_point(value: float) -> float:
+	return sin(value) + cos(value)
+
+func array_create() -> Array:
+	return [1, 2, 3]
+
+func make_callable() -> Callable:
+	return func() -> int: return 42
+
+func breakpoint_check() -> void:
+	breakpoint
+
+func fault(value: String) -> String:
+	return value[10000]
+
+# Repeated calls with live floating-point values and backedges.
+func math_loop(value: float, count: int) -> float:
+	var answer := value
+	for i in count:
+		var keep := answer * 0.25 + 0.125
+		answer = sin(answer) + cos(keep) + atan2(keep, answer + 2.0)
+	return answer
+
+func math_wide(a: float, b: float, c: float, d: float, e: float, f: float, g: float, h: float) -> float:
+	return cubic_interpolate_in_time(a, b, c, d, e, f, g, h)
+
+func math_ternary(a: float, b: float, weight: float) -> float:
+	return lerp(a, b, weight)
+
+func math_predicate(value: float) -> bool:
+	return is_nan(value)
+
+func random_float() -> float:
+	return randf_range(0.75, 0.75)
+
+func dictionary_edit(value: Dictionary) -> int:
+	value["answer"] = 42
+	return int(value["answer"])

--- a/src/gdscript/compiler/tests/test_await.cpp
+++ b/src/gdscript/compiler/tests/test_await.cpp
@@ -1,3 +1,4 @@
+#include "dyncall_shim.h"
 // AWAIT lowering tests: frame handoff, state dispatch, barrier correctness.
 // Runs compiled coroutines on libriscv against a minimal host stub.
 // Handle promotion covered by test_await_host_* in tests/test_basic.gd.
@@ -775,6 +776,7 @@ void test_the_frame_starts_out_nil() {
 } // namespace
 
 int main() {
+	sgd_install_test_dyncalls();
 	std::cout << "=== Await Tests ===" << std::endl << std::endl;
 
 	test_one_suspension();

--- a/src/gdscript/compiler/tests/test_breakpoints.cpp
+++ b/src/gdscript/compiler/tests/test_breakpoints.cpp
@@ -1,3 +1,4 @@
+#include "dyncall_shim.h"
 // ECALL_BREAKPOINT on a real libriscv machine: placement, register
 // transparency, line-table/a0 agreement, and shadow-stack presence.
 #include "../compiler.h"
@@ -542,6 +543,7 @@ void test_a_typed_parameter_reads_back_after_assignment() {
 } // namespace
 
 int main() {
+	sgd_install_test_dyncalls();
 	test_nothing_emitted_without_breakpoints();
 	test_stops_on_the_line_it_was_given();
 	test_a_line_with_no_code_is_not_a_stop();

--- a/src/gdscript/compiler/tests/test_call_overhead.cpp
+++ b/src/gdscript/compiler/tests/test_call_overhead.cpp
@@ -1,3 +1,4 @@
+#include "../syscall_abi.h"
 // Pin down the instruction sequences around a call: return, immediate folding,
 // int chaining, non-negative subscript elision, global handle elision.
 // Assertions are on emitted instruction shapes, not specific encodings.
@@ -119,7 +120,8 @@ bool is_store_through_return_pointer(uint32_t w) {
 }
 
 bool is_ecall(uint32_t w) {
-	return opcode_of(w) == 0x73 && funct3_of(w) == 0 && rd_of(w) == REG_ZERO && (w >> 20) == 0;
+	return gdscript::valid_counted_syscall_encoding(w) ||
+		(opcode_of(w) == 0x73 && funct3_of(w) == 0 && rd_of(w) == REG_ZERO && (w >> 20) == 0);
 }
 
 // `li a7, number` -- how a syscall says which one it is.
@@ -141,7 +143,8 @@ size_t count(const std::vector<uint32_t>& words, bool (*pred)(uint32_t)) {
 size_t count_syscall(const std::vector<uint32_t>& words, int number) {
 	size_t n = 0;
 	for (uint32_t w : words) {
-		if (selects_syscall(w, number)) {
+		if (selects_syscall(w, number) ||
+			(gdscript::valid_counted_syscall_encoding(w) && (w >> 20) == unsigned(number))) {
 			n++;
 		}
 	}

--- a/src/gdscript/compiler/tests/test_callables.cpp
+++ b/src/gdscript/compiler/tests/test_callables.cpp
@@ -1,3 +1,4 @@
+#include "dyncall_shim.h"
 // Callables: lambdas, a function name used as a value, and calling a Callable
 // held in a variable.
 //
@@ -923,6 +924,7 @@ void test_lifted_names_stay_out_of_the_way() {
 } // namespace
 
 int main() {
+	sgd_install_test_dyncalls();
 	std::cout << "=== Callable Tests ===" << std::endl << std::endl;
 
 	test_a_lambda_is_a_callable();

--- a/src/gdscript/compiler/tests/test_debug_info.cpp
+++ b/src/gdscript/compiler/tests/test_debug_info.cpp
@@ -1,3 +1,4 @@
+#include "dyncall_shim.h"
 // DebugLayout shadow stack on a real libriscv machine. Outer frame lines
 // resolved from return addresses via the line table; nothing per statement.
 #include "../compiler.h"
@@ -345,6 +346,7 @@ void test_overflow_keeps_counting() {
 } // namespace
 
 int main() {
+	sgd_install_test_dyncalls();
 	test_off_by_default();
 	test_header();
 	test_call_stack_mid_call();

--- a/src/gdscript/compiler/tests/test_differential.cpp
+++ b/src/gdscript/compiler/tests/test_differential.cpp
@@ -1,3 +1,4 @@
+#include "dyncall_shim.h"
 // Differential testing: the IR interpreter against the real machine.
 //
 // The IR interpreter and the RISC-V backend are two independent
@@ -597,6 +598,7 @@ Outcome run_source(const std::string& source) {
 } // namespace
 
 int main(int argc, char** argv) {
+	sgd_install_test_dyncalls();
 	// Two modes. Without arguments it runs the shared corpus, which is what the
 	// test suite does. With --fuzz it runs generated programs instead, which is
 	// what turns this check into a fuzzer: the generator produces programs

--- a/src/gdscript/compiler/tests/test_frames.cpp
+++ b/src/gdscript/compiler/tests/test_frames.cpp
@@ -1,3 +1,4 @@
+#include "../syscall_abi.h"
 // What a function's prologue and epilogue actually cost.
 //
 // Every function used to open with the same six instructions -- move sp, save
@@ -108,7 +109,8 @@ bool is_store_through_return_pointer(uint32_t w) {
 }
 
 bool is_ecall(uint32_t w) {
-	return opcode_of(w) == 0x73 && funct3_of(w) == 0 && rd_of(w) == REG_ZERO && (w >> 20) == 0;
+	return gdscript::valid_counted_syscall_encoding(w) ||
+		(opcode_of(w) == 0x73 && funct3_of(w) == 0 && rd_of(w) == REG_ZERO && (w >> 20) == 0);
 }
 
 // jal ra, offset -- a call to another function in the program.

--- a/src/gdscript/compiler/tests/test_instances.cpp
+++ b/src/gdscript/compiler/tests/test_instances.cpp
@@ -1,3 +1,4 @@
+#include "dyncall_shim.h"
 #include "../compiler.h"
 #include "scope_stub.h"
 #include "../codegen.h"
@@ -348,6 +349,7 @@ void test_a_record_initializes_its_members() {
 } // namespace
 
 int main() {
+	sgd_install_test_dyncalls();
 	std::cout << "=== Instance record tests ===" << std::endl;
 	test_storage_classification();
 	test_initializers_are_split();

--- a/src/gdscript/compiler/tests/test_instruction_budget.cpp
+++ b/src/gdscript/compiler/tests/test_instruction_budget.cpp
@@ -1,3 +1,4 @@
+#include "dyncall_shim.h"
 // Deterministic code-quality guardrail for the interpreter hot path. Wall-clock
 // benchmarks are machine-dependent; the libriscv instruction counter is not.
 #include "../compiler.h"
@@ -142,6 +143,7 @@ void check_budget(const std::vector<uint8_t>& elf, const std::string& function,
 } // namespace
 
 int main() {
+	sgd_install_test_dyncalls();
 	Compiler compiler;
 	const std::vector<uint8_t> elf = compiler.compile(SOURCE);
 	if (elf.empty()) {

--- a/src/gdscript/compiler/tests/test_load.cpp
+++ b/src/gdscript/compiler/tests/test_load.cpp
@@ -1,3 +1,4 @@
+#include "../syscall_abi.h"
 // LOAD_RESOURCE vs LOAD_RESOURCE_VAR lowering and DCE immunity.
 #include "../lexer.h"
 #include "../parser.h"
@@ -212,13 +213,13 @@ static void test_emitted_syscall() {
 
 	const std::vector<uint8_t> literal =
 		machine_code("func test():\n\treturn load(\"res://icon.svg\")\n");
-	assert(count_instruction(literal, li(REG_A7, ECALL_LOAD)) == 1);
+	assert(count_instruction(literal, gdscript::encode_counted_syscall(ECALL_LOAD, 3, 0, false)) == 1);
 	// A1 = length (characters).
 	assert(count_instruction(literal, li(REG_A1, 14)) == 1);
 	assert(count_instruction(literal, li(REG_A1, -1)) == 0);
 
 	const std::vector<uint8_t> computed = machine_code("func test(p):\n\treturn load(p)\n");
-	assert(count_instruction(computed, li(REG_A7, ECALL_LOAD)) == 1);
+	assert(count_instruction(computed, gdscript::encode_counted_syscall(ECALL_LOAD, 3, 0, false)) == 1);
 	// A1 = -1 (Variant path).
 	assert(count_instruction(computed, li(REG_A1, -1)) == 1);
 }

--- a/src/gdscript/compiler/tests/test_object_retain.cpp
+++ b/src/gdscript/compiler/tests/test_object_retain.cpp
@@ -1,3 +1,4 @@
+#include "../syscall_abi.h"
 #include "../codegen.h"
 #include "../ir_optimizer.h"
 #include "../ir_verifier.h"
@@ -65,7 +66,8 @@ int count_syscalls(const std::vector<uint8_t>& code, int syscall) {
 		uint32_t second = 0;
 		std::memcpy(&first, code.data() + i, 4);
 		std::memcpy(&second, code.data() + i + 4, 4);
-		count += (first == li_a7 && second == ecall) ? 1 : 0;
+		count += ((first == li_a7 && second == ecall) ||
+			(gdscript::valid_counted_syscall_encoding(first) && (first >> 20) == unsigned(syscall))) ? 1 : 0;
 	}
 	return count;
 }

--- a/src/gdscript/compiler/tests/test_profiling.cpp
+++ b/src/gdscript/compiler/tests/test_profiling.cpp
@@ -1,3 +1,4 @@
+#include "dyncall_shim.h"
 // Runs profiled ELFs on a real libriscv machine and checks the accounting:
 // self excludes callees, total includes them, entry/exit balance across
 // recursion past MAX_DEPTH. INSTRUCTIONS clock throughout for determinism.
@@ -338,6 +339,7 @@ void test_recursion_overflows_the_shadow_stack() {
 } // namespace
 
 int main() {
+	sgd_install_test_dyncalls();
 	test_off_by_default();
 	test_header();
 	test_call_counts_and_nesting();

--- a/src/gdscript/compiler/tests/test_regressions.cpp
+++ b/src/gdscript/compiler/tests/test_regressions.cpp
@@ -1,3 +1,4 @@
+#include "../syscall_abi.h"
 // Regression tests for compiler bugs that produced wrong code silently.
 //
 // Every test here pins down a behaviour that was previously wrong in a way that
@@ -636,8 +637,9 @@ static void test_truthiness_of_a_global_read_in_place() {
 	for (size_t off = 0; off + 4 <= code.size(); off += 4) {
 		const uint32_t instr = word_at(code, off);
 		// li a7, ECALL_VEVAL
-		if (!is_addi(instr) || rd_of(instr) != REG_A7 || rs1_of(instr) != 0 ||
-			(int32_t(instr) >> 20) != ECALL_VEVAL) {
+		if (!(gdscript::valid_counted_syscall_encoding(instr) && (instr >> 20) == ECALL_VEVAL) &&
+			(!is_addi(instr) || rd_of(instr) != REG_A7 || rs1_of(instr) != 0 ||
+			(int32_t(instr) >> 20) != ECALL_VEVAL)) {
 			continue;
 		}
 		// a1 is the operand pointer: the last write of it before the syscall.

--- a/src/gdscript/compiler/tests/test_scope.cpp
+++ b/src/gdscript/compiler/tests/test_scope.cpp
@@ -1,3 +1,4 @@
+#include "../syscall_abi.h"
 #include "../lexer.h"
 #include "../parser.h"
 #include "../codegen.h"
@@ -229,7 +230,8 @@ static bool contains_word(const std::vector<uint8_t>& elf, uint32_t word) {
 	for (size_t i = 0; i + 4 <= elf.size(); i++) {
 		const uint32_t at = uint32_t(elf[i]) | (uint32_t(elf[i + 1]) << 8) |
 			(uint32_t(elf[i + 2]) << 16) | (uint32_t(elf[i + 3]) << 24);
-		if (at == word) {
+		if (at == word || ((word & 0xfffff) == ((17u << 7) | 0x13u) &&
+			gdscript::valid_counted_syscall_encoding(at) && (at >> 20) == (word >> 20))) {
 			return true;
 		}
 	}
@@ -241,7 +243,8 @@ static int count_word(const std::vector<uint8_t>& elf, uint32_t word) {
 	for (size_t i = 0; i + 4 <= elf.size(); i++) {
 		const uint32_t at = uint32_t(elf[i]) | (uint32_t(elf[i + 1]) << 8) |
 			(uint32_t(elf[i + 2]) << 16) | (uint32_t(elf[i + 3]) << 24);
-		if (at == word) {
+		if (at == word || ((word & 0xfffff) == ((17u << 7) | 0x13u) &&
+			gdscript::valid_counted_syscall_encoding(at) && (at >> 20) == (word >> 20))) {
 			count++;
 		}
 	}
@@ -566,7 +569,8 @@ static bool sets_a_saved_register(const std::vector<uint8_t>& elf, int syscall, 
 	for (size_t i = 0; i + 4 <= elf.size(); i++) {
 		const uint32_t word = uint32_t(elf[i]) | (uint32_t(elf[i + 1]) << 8) |
 			(uint32_t(elf[i + 2]) << 16) | (uint32_t(elf[i + 3]) << 24);
-		if (word != marker) {
+		if (word != marker && !(gdscript::valid_counted_syscall_encoding(word) &&
+			(word >> 20) == unsigned(syscall))) {
 			continue;
 		}
 		for (size_t k = 1; k <= window && i + 4 * (k + 1) <= elf.size(); k++) {

--- a/src/gdscript/compiler/tests/test_syscall_codegen.cpp
+++ b/src/gdscript/compiler/tests/test_syscall_codegen.cpp
@@ -1,0 +1,143 @@
+#include "compiler.h"
+#include "syscall_abi.h"
+#include "../../../../ext/libriscv/lib/libriscv/dyncall.hpp"
+#include <elf.h>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+
+static void require(bool condition, const char* message) {
+	if (!condition) throw std::runtime_error(message);
+}
+static uint32_t encode(unsigned number, unsigned inputs, unsigned outputs, bool floats = true) {
+	return riscv::Dyncall::encode(number, inputs, outputs, floats);
+}
+int main(int argc, char** argv) try {
+	using namespace gdscript;
+	// Counts are independently stated here, including operation-specific forms.
+	using Signature = std::tuple<unsigned, int64_t, unsigned, unsigned>;
+	const Signature expected[] = {
+		{ECALL_ARRAY_SIZE, -1, 1, 1}, {ECALL_STRING_SIZE, -1, 1, 1},
+		{ECALL_STRING_AT, -1, 2, 1}, {ECALL_STRING_BATCH, -1, 3, 1},
+		{ECALL_ARRAY_BATCH, -1, 4, 1}, {ECALL_STRING_CODEPOINT_BATCH, -1, 4, 1},
+		{ECALL_CALLABLE_CREATE, -1, 4, 1},
+		{ECALL_VCREATE, -1, 4, 0}, {ECALL_ARRAY_AT, -1, 3, 1},
+		{ECALL_DICTIONARY_OPS, int(Dictionary_Op::GET), 5, 1},
+		{ECALL_VSCOPE, int(Scope_Op::MARK), 1, 1},
+		{ECALL_DICTIONARY_OPS, int(Dictionary_Op::GET_SIZE), 2, 1},
+		{ECALL_UTILITY, int(Utility_Op::RANDI), 1, 1},
+		{ECALL_UTILITY, int(Utility_Op::RANDI_RANGE), 3, 1},
+		{ECALL_UTILITY, int(Utility_Op::NEAREST_PO2), 2, 1},
+		{ECALL_UTILITY, int(Utility_Op::SIN), 1, 0},
+	};
+	for (auto [number, op, inputs, outputs] : expected) {
+		for (unsigned i = 0; i < 32; i++) for (unsigned o = 0; o < 32; o++) {
+			const auto word = (number << 20) | (o << 15) | (7u << 12) | (i << 7) | 0x5b;
+			const bool fp = number == ECALL_UTILITY && op == int(Utility_Op::SIN);
+			const bool counts = i == (16 | inputs) &&
+				(o == (28 | outputs) || (!fp && o == (24 | outputs)));
+			const bool general_dictionary = number == ECALL_DICTIONARY_OPS &&
+				i == 21 && (o == 29 || o == 25);
+			require(valid_counted_syscall(word, op) == (counts || general_dictionary), "signature validation mismatch");
+		}
+		require(valid_counted_syscall_encoding(encode(number, inputs, outputs)), "valid encoding refused");
+	}
+	require(!valid_counted_syscall(encode(ECALL_VSCOPE, 1, 1), int(Scope_Op::RELEASE)), "scope RELEASE accepted as MARK");
+	require(!valid_counted_syscall(encode(ECALL_UTILITY, 1, 1), int(Utility_Op::SIN)), "FP utility accepted as GPR-only");
+	require(!valid_counted_syscall(encode(ECALL_DICTIONARY_OPS, 2, 1), int(Dictionary_Op::GET)), "dictionary GET accepted as GET_SIZE");
+	for (unsigned i = 0; i < 4096; i++) {
+		if (i < GAME_API_BASE || i >= ECALL_LAST)
+			require(!valid_counted_syscall_encoding(encode(i, 1, 1)), "unknown syscall accepted");
+	}
+	for (unsigned n = 0; n < 4096; n++)
+		for (unsigned i = 0; i <= 8; i++) for (unsigned o = 0; o <= 2; o++)
+			for (bool fp : {false, true})
+				require(encode_counted_syscall(n, i, o, fp) == encode(n, i, o, fp), "compiler/upstream encoding drift");
+	// Neither the old counted form nor a tag-stripped word is accepted.
+	for (unsigned f = 0; f < 8; f++) for (unsigned rd = 0; rd < 32; rd++)
+		for (unsigned rs = 0; rs < 32; rs++) {
+			const auto w = (ECALL_ARRAY_SIZE << 20) | (rs << 15) | (f << 12) | (rd << 7) | 0x5b;
+			require(valid_counted_syscall_encoding(w) == (w == encode(ECALL_ARRAY_SIZE, 1, 1) || w == encode(ECALL_ARRAY_SIZE, 1, 1, false)), "tag validation mismatch");
+		}
+	require(!valid_counted_syscall(encode(ECALL_UTILITY, 1, 0), int(Utility_Op::STR)), "boxed utility accepted as FP");
+	require(!valid_counted_syscall(encode(ECALL_UTILITY, 1, 0), 4095), "unknown utility accepted as FP");
+	require(!valid_counted_syscall_encoding(encode(ECALL_UTILITY, 1, 0, false)), "FP utility accepted without synchronization");
+	std::ifstream input(SGD_SYSCALL_SOURCE);
+	std::string source{std::istreambuf_iterator<char>(input), {}};
+	Compiler compiler;
+	auto elf = compiler.compile(source);
+	if (elf.empty()) throw std::runtime_error(compiler.get_error());
+	auto legacy = elf;
+	auto malformed = elf;
+	auto malformed_fp = elf;
+	auto old_encoding = elf;
+	bool changed_fp = false;
+	bool changed_operation = false;
+	Elf64_Ehdr header{};
+	std::memcpy(&header, elf.data(), sizeof(header));
+	std::set<std::tuple<unsigned, unsigned, unsigned>> found;
+	std::set<unsigned> ecalls;
+	for (unsigned section = 0; section < header.e_shnum; section++) {
+		Elf64_Shdr sh{};
+		std::memcpy(&sh, elf.data() + header.e_shoff + section * header.e_shentsize, sizeof(sh));
+		if (!(sh.sh_flags & SHF_EXECINSTR)) continue;
+		uint32_t previous = 0;
+		for (size_t off = sh.sh_offset; off + 4 <= sh.sh_offset + sh.sh_size; off += 4) {
+			uint32_t word;
+			std::memcpy(&word, elf.data() + off, sizeof(word));
+			if ((word & 127) == 0x5b) {
+				require(valid_counted_syscall_encoding(word), "compiler emitted an invalid counted syscall");
+				require(riscv::Dyncall::floats(word) == ((word >> 20) == ECALL_UTILITY && riscv::Dyncall::outputs(word) == 0), "incorrect compiler FP flag");
+				found.emplace(word >> 20, riscv::Dyncall::inputs(word), riscv::Dyncall::outputs(word));
+				require(previous != ((word >> 20) << 20 | (17 << 7) | 0x13), "redundant a7 setup before dyncall");
+				const uint32_t uncounted = (word & 0xfff00000u) | 0x5b;
+				std::memcpy(legacy.data() + off, &uncounted, sizeof(uncounted));
+				const uint32_t old = ((word >> 20) << 20) | (riscv::Dyncall::outputs(word) << 15) |
+					(1u << 12) | (riscv::Dyncall::inputs(word) << 7) | 0x5b;
+				std::memcpy(old_encoding.data() + off, &old, sizeof(old));
+				if (word == encode(ECALL_UTILITY, 1, 0)) {
+					const uint32_t bad = encode(ECALL_UTILITY, 1, 0, false);
+					std::memcpy(malformed_fp.data() + off, &bad, sizeof(bad));
+					changed_fp = true;
+				}
+				if (word == encode(ECALL_UTILITY, 3, 1, false)) {
+					// RANDI's valid signature cannot be used for RANDI_RANGE.
+					const uint32_t bad = encode(ECALL_UTILITY, 1, 1);
+					std::memcpy(malformed.data() + off, &bad, sizeof(bad));
+					changed_operation = true;
+				}
+			} else if (word == 0x73 && (previous & 0xfffff) == ((17 << 7) | 0x13)) {
+				ecalls.insert(previous >> 20);
+			}
+			previous = word;
+		}
+	}
+	for (auto [number, op, inputs, outputs] : expected)
+		if (!found.count({number, inputs, outputs}))
+			throw std::runtime_error("missing compiler lowering " + std::to_string(number) + "/" + std::to_string(inputs) + "/" + std::to_string(outputs));
+	for (unsigned number : {ECALL_UTILITY, ECALL_BREAKPOINT, ECALL_VSCOPE})
+		require(ecalls.count(number), "missing required full-state ECALL");
+	for (unsigned number : {ECALL_VCREATE, ECALL_ARRAY_AT})
+		require(!ecalls.count(number), "eligible syscall still lowered to ECALL");
+	for (unsigned number = GAME_API_BASE; number < ECALL_LAST; number++) {
+		const auto abi = syscall_abi(number);
+		if (abi.counted)
+			require(valid_counted_syscall_encoding(encode(number, abi.inputs, abi.outputs)), "new ABI signature refused");
+	}
+	require(changed_fp, "missing FP mismatch fixture");
+	require(changed_operation, "missing malformed operation fixture");
+	if (argc > 1) {
+		std::filesystem::path out(argv[1]);
+		std::filesystem::create_directories(out);
+		std::ofstream(out / "counted.elf", std::ios::binary).write(reinterpret_cast<const char*>(elf.data()), elf.size());
+		std::ofstream(out / "legacy.elf", std::ios::binary).write(reinterpret_cast<const char*>(legacy.data()), legacy.size());
+		std::ofstream(out / "malformed-fp.elf", std::ios::binary).write(reinterpret_cast<const char*>(malformed_fp.data()), malformed_fp.size());
+		std::ofstream(out / "old-encoding.elf", std::ios::binary).write(reinterpret_cast<const char*>(old_encoding.data()), old_encoding.size());
+		std::ofstream(out / "malformed.elf", std::ios::binary).write(reinterpret_cast<const char*>(malformed.data()), malformed.size());
+	}
+	std::cout << "PASS 16 compiler signatures, exhaustive ABI/tag checks, full-state fallbacks, no redundant a7 loads\n";
+} catch (const std::exception& e) { std::cerr << e.what() << '\n'; return 1; }


### PR DESCRIPTION
The decoder and audited syscall signatures landed in 5449f59, but SafeGDScript's compiler still emits ECALL and loads a7 at each call site. Route those sites through `emit_syscall()` so audited handlers use counted custom-2 calls. For example, Array.size() now emits a 1-input/1-output dyncall, while scope RELEASE and reentrant/debugger calls retain ECALL.

Depends on https://github.com/libriscv/libriscv/pull/434. The libriscv submodule pins 01909a89, which adds the optional FP synchronization flag. Integer-only handlers clear bit 17; scalar math retains fa0-fa7/fa0-fa1 synchronization. The decoder accepts older counted words and rejects a cleared FP flag for float utilities. Both compiler paths build the same sources; syscall numbers and artifact layout are unchanged.

The conversion retains syscall frame checks and instruction-budget accounting. Compiler tests now recognize both call forms, and bare-machine fixtures install validated dyncall dispatch. Added exhaustive signature/flag checks and generated ELF fixtures, including forged FP flags and operation mismatches.

Validation: all 62 compiler CTests pass, including differential execution, instruction budgets, profiling, debugging, coroutines, and callables. The new libriscv regression passes 9,245 assertions each with asmjit and Full. Local sanitizer runs disabled LeakSanitizer because the runner uses ptrace.

The GS+ integration gate also passes with the matching compiler metadata and runtime in a rebuilt editor: interpreter, JIT and Full execute real Sandbox handlers, including FP math, malformed FP flags, operation mismatches, callables, exceptions and instruction penalties. This run used an isolated module snapshot because unrelated protection-exporter work in the shared checkout did not build.
